### PR TITLE
fix: Include tests directory in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ COPY package.json ./package.json
 COPY tsconfig.json ./tsconfig.json
 COPY scripts ./scripts
 COPY src ./src
+COPY tests ./tests
 COPY dfx.json ./dfx.json
 COPY canister_ids.json ./canister_ids.json
 


### PR DESCRIPTION
This PR fixes the linting issue by including the tests directory in the Docker build process.

## Changes
- Modified Dockerfile to copy the tests directory into the Docker image
- This ensures that when the linting scripts run inside the container, they can find the tests directory

This should fix the failing test workflow in the CI pipeline that was showing:
```
Error: Invalid value for 'SRC ...': Path 'tests' does not exist.
```