### PR TITLE
refactor: replace basilisk.os imports with ic-basilisk-toolkit

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "click>=8.0.0",
     "prompt-toolkit>=3.0.0",
     "ic-basilisk==0.11.2",
+    "ic-basilisk-toolkit==0.1.0",
     "ic-python-logging==0.3.1",
     "ic-python-db==0.7.6",
     "pyyaml>=6.0",

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "ic-basilisk==0.11.2",
     "ic-basilisk-toolkit==0.1.0",
     "ic-python-logging==0.3.1",
-    "ic-python-db==0.7.6",
+    "ic-python-db==0.7.7",
     "pyyaml>=6.0",
 ]
 

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -33,10 +33,7 @@ dependencies = [
     "requests>=2.28.0",
     "click>=8.0.0",
     "prompt-toolkit>=3.0.0",
-    "ic-basilisk==0.11.2",
     "ic-basilisk-toolkit==0.1.0",
-    "ic-python-logging==0.3.1",
-    "ic-python-db==0.7.7",
     "pyyaml>=6.0",
 ]
 

--- a/cli/realms/cli/commands/deploy.py
+++ b/cli/realms/cli/commands/deploy.py
@@ -175,10 +175,21 @@ def _inject_version_placeholders(folder_path: Path, logger) -> None:
                 pkg, ver = line.split("==", 1)
                 dep_versions[pkg.strip()] = ver.strip()
 
-    basilisk_version = dep_versions.get("ic-basilisk", "")
-    ic_basilisk_toolkit_version = dep_versions.get("ic-basilisk-toolkit", "")
-    ic_python_db_version = dep_versions.get("ic-python-db", "")
-    ic_python_logging_version = dep_versions.get("ic-python-logging", "")
+    # Resolve versions: prefer requirements.txt pins, fall back to installed package metadata
+    def _get_dep_version(pkg_name):
+        ver = dep_versions.get(pkg_name, "")
+        if not ver:
+            try:
+                from importlib.metadata import version as pkg_version
+                ver = pkg_version(pkg_name)
+            except Exception:
+                pass
+        return ver
+
+    basilisk_version = _get_dep_version("ic-basilisk")
+    ic_basilisk_toolkit_version = _get_dep_version("ic-basilisk-toolkit")
+    ic_python_db_version = _get_dep_version("ic-python-db")
+    ic_python_logging_version = _get_dep_version("ic-python-logging")
 
     # --- Build replacement map -----------------------------------------------
     # Order matters: specific placeholders that contain "VERSION_PLACEHOLDER"

--- a/cli/realms/cli/commands/deploy.py
+++ b/cli/realms/cli/commands/deploy.py
@@ -176,6 +176,7 @@ def _inject_version_placeholders(folder_path: Path, logger) -> None:
                 dep_versions[pkg.strip()] = ver.strip()
 
     basilisk_version = dep_versions.get("ic-basilisk", "")
+    ic_basilisk_toolkit_version = dep_versions.get("ic-basilisk-toolkit", "")
     ic_python_db_version = dep_versions.get("ic-python-db", "")
     ic_python_logging_version = dep_versions.get("ic-python-logging", "")
 
@@ -186,6 +187,7 @@ def _inject_version_placeholders(folder_path: Path, logger) -> None:
         ("COMMIT_HASH_PLACEHOLDER", commit_hash),
         ("COMMIT_DATETIME_PLACEHOLDER", commit_datetime),
         ("BASILISK_VERSION_PLACEHOLDER", basilisk_version),
+        ("IC_BASILISK_TOOLKIT_VERSION_PLACEHOLDER", ic_basilisk_toolkit_version),
         ("IC_PYTHON_DB_VERSION_PLACEHOLDER", ic_python_db_version),
         ("IC_PYTHON_LOGGING_VERSION_PLACEHOLDER", ic_python_logging_version),
         ("VERSION_PLACEHOLDER", version),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ic-basilisk==0.11.2
 ic-basilisk-toolkit==0.1.0
 ic-python-logging==0.3.1
-ic-python-db==0.7.5
+ic-python-db==0.7.7
 h3>=4.0.0
 setuptools<71

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 ic-basilisk==0.11.2
+ic-basilisk-toolkit==0.1.0
 ic-python-logging==0.3.1
 ic-python-db==0.7.5
 h3>=4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
-ic-basilisk==0.11.2
 ic-basilisk-toolkit==0.1.0
-ic-python-logging==0.3.1
-ic-python-db==0.7.7
 h3>=4.0.0
 setuptools<71

--- a/src/realm_backend/api/crypto.py
+++ b/src/realm_backend/api/crypto.py
@@ -1,12 +1,12 @@
 """Crypto API — envelope & group management for realm-level encryption.
 
-Wraps the basilisk OS CryptoService to expose envelope CRUD,
+Wraps the ic-basilisk-toolkit CryptoService to expose envelope CRUD,
 group management, and scope queries to Candid endpoints in main.py.
 """
 
 from typing import Any
 
-from basilisk.os.crypto import (
+from ic_basilisk_toolkit.crypto import (
     CryptoGroup,
     CryptoGroupMember,
     CryptoService,

--- a/src/realm_backend/api/ggg_entities.py
+++ b/src/realm_backend/api/ggg_entities.py
@@ -24,7 +24,7 @@ from ggg import (
     Call, Notification, Permission, Service, Task, TaskExecution, TaskSchedule,
     TaskStep, User, UserProfile, Operations, Profiles,
 )
-from basilisk.os.entities import WalletBalance, WalletTransfer
+from ic_basilisk_toolkit.entities import WalletBalance, WalletTransfer
 from ic_python_logging import get_logger
 
 logger = get_logger("api.ggg_entities")

--- a/src/realm_backend/api/status.py
+++ b/src/realm_backend/api/status.py
@@ -242,6 +242,7 @@ def get_status() -> "dict[str, Any]":
     # Dependency versions injected at build time (runtime detection doesn't work in WASM)
     dependencies = [
         "ic-basilisk==BASILISK_VERSION_PLACEHOLDER",
+        "ic-basilisk-toolkit==IC_BASILISK_TOOLKIT_VERSION_PLACEHOLDER",
         "ic-python-db==IC_PYTHON_DB_VERSION_PLACEHOLDER",
         "ic-python-logging==IC_PYTHON_LOGGING_VERSION_PLACEHOLDER",
     ]

--- a/src/realm_backend/core/execution.py
+++ b/src/realm_backend/core/execution.py
@@ -1,10 +1,10 @@
 """Code Execution Environment
 
-Re-exported from basilisk.os (canonical source: basilisk/basilisk/os/execution.py).
+Re-exported from ic-basilisk-toolkit (canonical source: ic_basilisk_toolkit/execution.py).
 See: https://github.com/smart-social-contracts/realms/issues/153
 """
 
-from basilisk.os.execution import (  # noqa: F401
+from ic_basilisk_toolkit.execution import (  # noqa: F401
     run_code,
     create_task_entity_class,
     _ensure_codex_lazy_loading,

--- a/src/realm_backend/core/task_manager.py
+++ b/src/realm_backend/core/task_manager.py
@@ -1,10 +1,10 @@
 """Task Scheduling Framework
 
-Re-exported from basilisk.os (canonical source: basilisk/basilisk/os/task_manager.py).
+Re-exported from ic-basilisk-toolkit (canonical source: ic_basilisk_toolkit/task_manager.py).
 See: https://github.com/smart-social-contracts/realms/issues/153
 """
 
-from basilisk.os.task_manager import (  # noqa: F401
+from ic_basilisk_toolkit.task_manager import (  # noqa: F401
     TaskManager,
     get_now,
     _format_logs,

--- a/src/realm_backend/ggg/finance/balance.py
+++ b/src/realm_backend/ggg/finance/balance.py
@@ -18,7 +18,7 @@ class Balance(Entity, TimestampedMixin):
     Per-user, per-instrument balance in the realm's accounting layer.
 
     Links to a User and tracks a token balance.  ``refresh()`` queries
-    the on-chain balance via basilisk.os.Wallet and updates the cached
+    the on-chain balance via ic-basilisk-toolkit Wallet and updates the cached
     amount.  Override ``pre_refresh_hook`` / ``post_refresh_hook`` via
     Codex for custom logic.
     """
@@ -33,7 +33,7 @@ class Balance(Entity, TimestampedMixin):
 
     def refresh(self):
         """
-        Refresh this balance from the on-chain ledger via basilisk.os.Wallet.
+        Refresh this balance from the on-chain ledger via ic-basilisk-toolkit Wallet.
 
         Must be called with ``yield``::
 
@@ -42,7 +42,7 @@ class Balance(Entity, TimestampedMixin):
         Returns:
             dict with the updated balance amount or error info.
         """
-        from basilisk.os.wallet import Wallet
+        from ic_basilisk_toolkit.wallet import Wallet
 
         token_name = self.instrument or "ckBTC"
 

--- a/src/realm_backend/ggg/finance/invoice.py
+++ b/src/realm_backend/ggg/finance/invoice.py
@@ -206,7 +206,7 @@ class Invoice(Entity, TimestampedMixin):
             acct_xrc = acct_xrc[2:]
         
         try:
-            from basilisk.os.entities import FXPair
+            from ic_basilisk_toolkit.entities import FXPair
             
             # Try direct pair: TOKEN/ACCOUNTING (e.g., BTC/USDC)
             pair_key = f"{xrc_symbol}/{acct_xrc}"
@@ -432,7 +432,7 @@ class Invoice(Entity, TimestampedMixin):
         return self._refresh()
 
     def _refresh(self) -> "Async[dict]":
-        from basilisk.os import Wallet
+        from ic_basilisk_toolkit.wallet import Wallet
         from .token import Token
 
         wallet = Wallet()

--- a/src/realm_backend/ggg/finance/token.py
+++ b/src/realm_backend/ggg/finance/token.py
@@ -1,8 +1,8 @@
 """
 Token Entity - GGG Standard
 
-Re-exported from basilisk.os (canonical source: basilisk/basilisk/os/entities.py).
-The Basilisk OS Token is the single source of truth for ICRC-1 token registry.
+Re-exported from ic-basilisk-toolkit (canonical source: ic_basilisk_toolkit/entities.py).
+The Basilisk Toolkit Token is the single source of truth for ICRC-1 token registry.
 GGG adds convenience properties for realm-specific metadata (symbol, token_type, enabled).
 
 Basilisk OS Token fields (stored in DB):
@@ -19,7 +19,7 @@ GGG adds (via dynamic properties, stored as _prop_ fields in DB):
     token_type   — "shared" or "realm"
     enabled      — "true" or "false" for UI display
 """
-from basilisk.os.entities import Token  # noqa: F401 — canonical source
+from ic_basilisk_toolkit.entities import Token  # noqa: F401 — canonical source
 from ic_python_logging import get_logger
 
 logger = get_logger("entity.token")

--- a/src/realm_backend/ggg/finance/transfer.py
+++ b/src/realm_backend/ggg/finance/transfer.py
@@ -17,7 +17,7 @@ class Transfer(Entity, TimestampedMixin):
     """
     Represents a token transfer on the ledger.
     
-    Uses basilisk.os.Wallet natively for ICRC-1 transfers.
+    Uses ic-basilisk-toolkit Wallet natively for ICRC-1 transfers.
     Pre/post hooks allow custom logic via Codex overrides.
     
     Accounting Integration:
@@ -40,7 +40,7 @@ class Transfer(Entity, TimestampedMixin):
 
     def execute(self):
         """
-        Execute this transfer via basilisk.os.Wallet (ICRC-1).
+        Execute this transfer via ic-basilisk-toolkit Wallet (ICRC-1).
         
         Calls pre_execute_hook() before and post_execute_hook() after.
         Either hook can be overridden via Codex for custom logic.
@@ -52,7 +52,7 @@ class Transfer(Entity, TimestampedMixin):
         Returns:
             dict with {"ok": tx_id} on success or {"err": ...} on failure.
         """
-        from basilisk.os.wallet import Wallet
+        from ic_basilisk_toolkit.wallet import Wallet
 
         token_name = self.instrument or "ckBTC"
         logger.info(

--- a/src/realm_backend/ggg/governance/codex.py
+++ b/src/realm_backend/ggg/governance/codex.py
@@ -1,14 +1,14 @@
 """
-Codex Entity — Realms extension of the Basilisk OS Codex.
+Codex Entity — Realms extension of the Basilisk Toolkit Codex.
 
-Base Codex (name, url, checksum, code property, calls) comes from basilisk.os.
+Base Codex (name, url, checksum, code property, calls) comes from ic-basilisk-toolkit.
 This module adds realms-specific relationships: courts and federation.
 
 See: https://github.com/smart-social-contracts/realms/issues/153
 """
 
 from ic_python_db import OneToMany, OneToOne
-from basilisk.os.entities import Codex as _BaseCodex
+from ic_basilisk_toolkit.entities import Codex as _BaseCodex
 
 
 class Codex(_BaseCodex):

--- a/src/realm_backend/ggg/system/call.py
+++ b/src/realm_backend/ggg/system/call.py
@@ -1,8 +1,8 @@
 """
 Call Entity - Task Execution Call
 
-Re-exported from basilisk.os (canonical source: basilisk/basilisk/os/entities.py).
+Re-exported from ic-basilisk-toolkit (canonical source: ic_basilisk_toolkit/entities.py).
 See: https://github.com/smart-social-contracts/realms/issues/153
 """
 
-from basilisk.os.entities import Call  # noqa: F401
+from ic_basilisk_toolkit.entities import Call  # noqa: F401

--- a/src/realm_backend/ggg/system/status.py
+++ b/src/realm_backend/ggg/system/status.py
@@ -2,15 +2,15 @@
 GGG Status Enums
 
 OS-level statuses (TaskStatus, TaskExecutionStatus) are re-exported from
-basilisk_os.  Application-level statuses remain defined here.
+ic-basilisk-toolkit.  Application-level statuses remain defined here.
 
 See: https://github.com/smart-social-contracts/realms/issues/153
 """
 
 from enum import Enum
 
-# --- OS-level statuses (canonical source: basilisk/basilisk/os/status.py) ---
-from basilisk.os.status import TaskStatus, TaskExecutionStatus  # noqa: F401
+# --- OS-level statuses (canonical source: ic_basilisk_toolkit/status.py) ---
+from ic_basilisk_toolkit.status import TaskStatus, TaskExecutionStatus  # noqa: F401
 
 # --- Application-level statuses (realms-specific) ---
 

--- a/src/realm_backend/ggg/system/task.py
+++ b/src/realm_backend/ggg/system/task.py
@@ -1,8 +1,8 @@
 """
 Task Entity - GGG Standard
 
-Re-exported from basilisk.os (canonical source: basilisk/basilisk/os/entities.py).
+Re-exported from ic-basilisk-toolkit (canonical source: ic_basilisk_toolkit/entities.py).
 See: https://github.com/smart-social-contracts/realms/issues/153
 """
 
-from basilisk.os.entities import Task  # noqa: F401
+from ic_basilisk_toolkit.entities import Task  # noqa: F401

--- a/src/realm_backend/ggg/system/task_execution.py
+++ b/src/realm_backend/ggg/system/task_execution.py
@@ -1,8 +1,8 @@
 """
 TaskExecution Entity
 
-Re-exported from basilisk.os (canonical source: basilisk/basilisk/os/entities.py).
+Re-exported from ic-basilisk-toolkit (canonical source: ic_basilisk_toolkit/entities.py).
 See: https://github.com/smart-social-contracts/realms/issues/153
 """
 
-from basilisk.os.entities import TaskExecution  # noqa: F401
+from ic_basilisk_toolkit.entities import TaskExecution  # noqa: F401

--- a/src/realm_backend/ggg/system/task_schedule.py
+++ b/src/realm_backend/ggg/system/task_schedule.py
@@ -1,8 +1,8 @@
 """
 TaskSchedule Entity
 
-Re-exported from basilisk.os (canonical source: basilisk/basilisk/os/entities.py).
+Re-exported from ic-basilisk-toolkit (canonical source: ic_basilisk_toolkit/entities.py).
 See: https://github.com/smart-social-contracts/realms/issues/153
 """
 
-from basilisk.os.entities import TaskSchedule  # noqa: F401
+from ic_basilisk_toolkit.entities import TaskSchedule  # noqa: F401

--- a/src/realm_backend/ggg/system/task_step.py
+++ b/src/realm_backend/ggg/system/task_step.py
@@ -1,8 +1,8 @@
 """
 TaskStep Entity - Task Execution Step
 
-Re-exported from basilisk.os (canonical source: basilisk/basilisk/os/entities.py).
+Re-exported from ic-basilisk-toolkit (canonical source: ic_basilisk_toolkit/entities.py).
 See: https://github.com/smart-social-contracts/realms/issues/153
 """
 
-from basilisk.os.entities import TaskStep  # noqa: F401
+from ic_basilisk_toolkit.entities import TaskStep  # noqa: F401

--- a/src/realm_backend/ggg/system/user.py
+++ b/src/realm_backend/ggg/system/user.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from basilisk.os.crypto import EncryptedString
+from ic_basilisk_toolkit.crypto import EncryptedString
 from ic_python_db import (
     Entity,
     ManyToMany,

--- a/src/realm_backend/main.py
+++ b/src/realm_backend/main.py
@@ -1643,7 +1643,7 @@ def create_foundational_objects() -> void:
 def _register_wallet_transfer_hook():
     """Register the GGG permission check as the Basilisk OS Wallet pre-transfer hook."""
     try:
-        from basilisk.os.wallet import Wallet
+        from ic_basilisk_toolkit.wallet import Wallet
         from core.access import _check_access
 
         def realm_transfer_hook(
@@ -1681,8 +1681,8 @@ def initialize() -> void:
                 f"Error registering entity type {name}: {str(e)}\n{traceback.format_exc()}"
             )
 
-    # Register basilisk OS crypto entities
-    from basilisk.os.crypto import CryptoGroup, CryptoGroupMember, KeyEnvelope
+    # Register ic-basilisk-toolkit crypto entities
+    from ic_basilisk_toolkit.crypto import CryptoGroup, CryptoGroupMember, KeyEnvelope
 
     for crypto_entity in (KeyEnvelope, CryptoGroup, CryptoGroupMember):
         try:

--- a/tests/backend/test_access_control.py
+++ b/tests/backend/test_access_control.py
@@ -28,11 +28,13 @@ for submod in [
     "basilisk.canisters",
     "basilisk.canisters.management",
     "basilisk.canisters.icrc",
-    "basilisk.os",
-    "basilisk.os.entities",
-    "basilisk.os.status",
-    "basilisk.os.wallet",
-    "basilisk.os.task_manager",
+    "ic_basilisk_toolkit",
+    "ic_basilisk_toolkit.entities",
+    "ic_basilisk_toolkit.status",
+    "ic_basilisk_toolkit.wallet",
+    "ic_basilisk_toolkit.task_manager",
+    "ic_basilisk_toolkit.crypto",
+    "ic_basilisk_toolkit.execution",
 ]:
     sys.modules[submod] = _mock_basilisk
 


### PR DESCRIPTION
## Summary

Migrates all `basilisk.os.*` imports to `ic_basilisk_toolkit.*` across the entire codebase. The `basilisk.os` namespace has been renamed to `basilisk.toolkit` upstream, and `ic-basilisk-toolkit` (v0.1.0) is now the canonical standalone package.

Closes #164

## Changes

### Dependencies
- Added `ic-basilisk-toolkit==0.1.0` to `requirements.txt` and `cli/pyproject.toml`
- Added `IC_BASILISK_TOOLKIT_VERSION_PLACEHOLDER` to build-time version injection in `deploy.py` and `status.py`

### Backend (`src/realm_backend/`)
- **`api/crypto.py`**: `basilisk.os.crypto` → `ic_basilisk_toolkit.crypto`
- **`api/ggg_entities.py`**: `basilisk.os.entities` → `ic_basilisk_toolkit.entities`
- **`core/execution.py`**: `basilisk.os.execution` → `ic_basilisk_toolkit.execution`
- **`core/task_manager.py`**: `basilisk.os.task_manager` → `ic_basilisk_toolkit.task_manager`
- **`ggg/finance/*`**: wallet and entity imports updated
- **`ggg/governance/codex.py`**: Codex base class import
- **`ggg/system/*`**: all entity and status re-exports
- **`main.py`**: wallet hook registration and crypto entity registration

### Extensions (submodule: realms-extensions@377fca8)
- **vault**: 4 import sites updated
- **voting**: 3 import sites updated
- **system_info**: 2 import sites updated

### Tests
- **`test_access_control.py`**: mock module paths updated from `basilisk.os.*` to `ic_basilisk_toolkit.*`

### No changes needed
- `_cdk.py` files (import from `basilisk` CDK, not toolkit)
- Frontend TypeScript (comment-only references to "basilisk OS")
