### PR TITLE
ci: rename DFX_IDENTITY_PEM → IC_IDENTITY_PEM

### DIFF
--- a/.github/workflows/_bootstrap-infra.yml
+++ b/.github/workflows/_bootstrap-infra.yml
@@ -27,7 +27,7 @@ on:
         description: "JSON {file_registry, file_registry_frontend, realm_installer}"
         value: ${{ jobs.bootstrap.outputs.infra-ids }}
     secrets:
-      DFX_IDENTITY_PEM:
+      IC_IDENTITY_PEM:
         required: false
 
 env:
@@ -59,10 +59,10 @@ jobs:
       - name: Configure dfx identity (non-local only)
         if: ${{ inputs.network != 'local' }}
         env:
-          DFX_IDENTITY_PEM: ${{ secrets.DFX_IDENTITY_PEM }}
+          IC_IDENTITY_PEM: ${{ secrets.IC_IDENTITY_PEM }}
         run: |
           mkdir -p ~/.config/dfx/identity/ci
-          printf '%s' "$DFX_IDENTITY_PEM" > ~/.config/dfx/identity/ci/identity.pem
+          printf '%s' "$IC_IDENTITY_PEM" > ~/.config/dfx/identity/ci/identity.pem
           chmod 600 ~/.config/dfx/identity/ci/identity.pem
           dfx identity use ci
 

--- a/.github/workflows/_install-mundus.yml
+++ b/.github/workflows/_install-mundus.yml
@@ -21,7 +21,7 @@ on:
         required: true
         type: string
     secrets:
-      DFX_IDENTITY_PEM:
+      IC_IDENTITY_PEM:
         required: false
 
 env:
@@ -53,10 +53,10 @@ jobs:
       - name: Configure dfx identity (non-local only)
         if: ${{ inputs.network != 'local' }}
         env:
-          DFX_IDENTITY_PEM: ${{ secrets.DFX_IDENTITY_PEM }}
+          IC_IDENTITY_PEM: ${{ secrets.IC_IDENTITY_PEM }}
         run: |
           mkdir -p ~/.config/dfx/identity/ci
-          printf '%s' "$DFX_IDENTITY_PEM" > ~/.config/dfx/identity/ci/identity.pem
+          printf '%s' "$IC_IDENTITY_PEM" > ~/.config/dfx/identity/ci/identity.pem
           chmod 600 ~/.config/dfx/identity/ci/identity.pem
           dfx identity use ci
 

--- a/.github/workflows/_publish-artifacts.yml
+++ b/.github/workflows/_publish-artifacts.yml
@@ -29,7 +29,7 @@ on:
         required: true
         type: string
     secrets:
-      DFX_IDENTITY_PEM:
+      IC_IDENTITY_PEM:
         required: false
 
 env:
@@ -67,10 +67,10 @@ jobs:
       - name: Configure dfx identity (non-local only)
         if: ${{ inputs.network != 'local' }}
         env:
-          DFX_IDENTITY_PEM: ${{ secrets.DFX_IDENTITY_PEM }}
+          IC_IDENTITY_PEM: ${{ secrets.IC_IDENTITY_PEM }}
         run: |
           mkdir -p ~/.config/dfx/identity/ci
-          printf '%s' "$DFX_IDENTITY_PEM" > ~/.config/dfx/identity/ci/identity.pem
+          printf '%s' "$IC_IDENTITY_PEM" > ~/.config/dfx/identity/ci/identity.pem
           chmod 600 ~/.config/dfx/identity/ci/identity.pem
           dfx identity use ci
 

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -73,7 +73,7 @@ jobs:
       network: staging
       descriptor: deployments/staging-mundus-layered.yml
     secrets:
-      DFX_IDENTITY_PEM: ${{ secrets.DFX_IDENTITY_PEM }}
+      IC_IDENTITY_PEM: ${{ secrets.IC_IDENTITY_PEM }}
 
   publish-artifacts-staging:
     needs: bootstrap-infra-staging
@@ -83,7 +83,7 @@ jobs:
       descriptor: deployments/staging-mundus-layered.yml
       infra-ids: ${{ needs.bootstrap-infra-staging.outputs.infra-ids }}
     secrets:
-      DFX_IDENTITY_PEM: ${{ secrets.DFX_IDENTITY_PEM }}
+      IC_IDENTITY_PEM: ${{ secrets.IC_IDENTITY_PEM }}
 
   install-mundus-staging:
     needs: [bootstrap-infra-staging, publish-artifacts-staging]
@@ -93,7 +93,7 @@ jobs:
       descriptor: deployments/staging-mundus-layered.yml
       infra-ids: ${{ needs.bootstrap-infra-staging.outputs.infra-ids }}
     secrets:
-      DFX_IDENTITY_PEM: ${{ secrets.DFX_IDENTITY_PEM }}
+      IC_IDENTITY_PEM: ${{ secrets.IC_IDENTITY_PEM }}
 
   verify-mundus-staging:
     needs: install-mundus-staging

--- a/.github/workflows/layered-deploy-dominion.yml
+++ b/.github/workflows/layered-deploy-dominion.yml
@@ -38,7 +38,7 @@ jobs:
       network: staging
       descriptor: deployments/staging-mundus-layered.yml
     secrets:
-      DFX_IDENTITY_PEM: ${{ secrets.DFX_IDENTITY_PEM }}
+      IC_IDENTITY_PEM: ${{ secrets.IC_IDENTITY_PEM }}
 
   publish-artifacts:
     if: ${{ !inputs.skip_publish }}
@@ -49,7 +49,7 @@ jobs:
       descriptor: deployments/staging-mundus-layered.yml
       infra-ids: ${{ needs.bootstrap-infra.outputs.infra-ids }}
     secrets:
-      DFX_IDENTITY_PEM: ${{ secrets.DFX_IDENTITY_PEM }}
+      IC_IDENTITY_PEM: ${{ secrets.IC_IDENTITY_PEM }}
 
   install-mundus:
     needs: [bootstrap-infra, publish-artifacts]
@@ -60,7 +60,7 @@ jobs:
       descriptor: deployments/staging-mundus-layered.yml
       infra-ids: ${{ needs.bootstrap-infra.outputs.infra-ids }}
     secrets:
-      DFX_IDENTITY_PEM: ${{ secrets.DFX_IDENTITY_PEM }}
+      IC_IDENTITY_PEM: ${{ secrets.IC_IDENTITY_PEM }}
 
   verify-mundus:
     needs: install-mundus


### PR DESCRIPTION
## Summary

Phase B (staging) of the freshly-merged `ci-main.yml` failed at the
first dfx call because the new layered workflows referenced a secret
named `DFX_IDENTITY_PEM` that doesn't exist in this repo. The actual
secret name (used by every other workflow — release, runtime-extension-deploy,
manual-agent-swarm) is `IC_IDENTITY_PEM`.

This patch renames every reference across the four reusable workflows,
`ci-main.yml`, and `layered-deploy-dominion.yml`. Phase A (local) was
already green on main; this unblocks Phase B.

## Test plan

- [ ] PR CI runs `ci-pr.yml` against this branch (Phase A only — same
      green pipeline as PR #170).
- [ ] After merge, `ci-main.yml` Phase B runs end-to-end against staging.

Made with [Cursor](https://cursor.com)