### PR TITLE
ci: import staging identity via plaintext-safe path

### DIFF
--- a/.github/workflows/_bootstrap-infra.yml
+++ b/.github/workflows/_bootstrap-infra.yml
@@ -61,10 +61,12 @@ jobs:
         env:
           IC_IDENTITY_PEM: ${{ secrets.IC_IDENTITY_PEM }}
         run: |
-          mkdir -p ~/.config/dfx/identity/ci
-          printf '%s' "$IC_IDENTITY_PEM" > ~/.config/dfx/identity/ci/identity.pem
-          chmod 600 ~/.config/dfx/identity/ci/identity.pem
+          printf '%s' "$IC_IDENTITY_PEM" > /tmp/identity.pem
+          chmod 600 /tmp/identity.pem
+          dfx identity import ci /tmp/identity.pem --storage-mode=plaintext --force
           dfx identity use ci
+          rm -f /tmp/identity.pem
+          echo "DFX_WARNING=-mainnet_plaintext_identity" >> "$GITHUB_ENV"
 
       - name: Start local replica (local only)
         if: ${{ inputs.network == 'local' }}

--- a/.github/workflows/_install-mundus.yml
+++ b/.github/workflows/_install-mundus.yml
@@ -55,10 +55,12 @@ jobs:
         env:
           IC_IDENTITY_PEM: ${{ secrets.IC_IDENTITY_PEM }}
         run: |
-          mkdir -p ~/.config/dfx/identity/ci
-          printf '%s' "$IC_IDENTITY_PEM" > ~/.config/dfx/identity/ci/identity.pem
-          chmod 600 ~/.config/dfx/identity/ci/identity.pem
+          printf '%s' "$IC_IDENTITY_PEM" > /tmp/identity.pem
+          chmod 600 /tmp/identity.pem
+          dfx identity import ci /tmp/identity.pem --storage-mode=plaintext --force
           dfx identity use ci
+          rm -f /tmp/identity.pem
+          echo "DFX_WARNING=-mainnet_plaintext_identity" >> "$GITHUB_ENV"
 
       - name: Start local replica (local only)
         if: ${{ inputs.network == 'local' }}

--- a/.github/workflows/_publish-artifacts.yml
+++ b/.github/workflows/_publish-artifacts.yml
@@ -69,10 +69,12 @@ jobs:
         env:
           IC_IDENTITY_PEM: ${{ secrets.IC_IDENTITY_PEM }}
         run: |
-          mkdir -p ~/.config/dfx/identity/ci
-          printf '%s' "$IC_IDENTITY_PEM" > ~/.config/dfx/identity/ci/identity.pem
-          chmod 600 ~/.config/dfx/identity/ci/identity.pem
+          printf '%s' "$IC_IDENTITY_PEM" > /tmp/identity.pem
+          chmod 600 /tmp/identity.pem
+          dfx identity import ci /tmp/identity.pem --storage-mode=plaintext --force
           dfx identity use ci
+          rm -f /tmp/identity.pem
+          echo "DFX_WARNING=-mainnet_plaintext_identity" >> "$GITHUB_ENV"
 
       - name: Start local replica (local only)
         if: ${{ inputs.network == 'local' }}


### PR DESCRIPTION
## Summary

After PR #171 fixed the secret name, Phase B (staging) of `ci-main.yml`
got past the empty-PEM error but now fails with:

> The ci identity is not stored securely. Do not use it to control a lot of cycles/ICP.

dfx blocks mainnet operations on PEMs that were dropped directly into
`~/.config/dfx/identity/<name>/identity.pem`. The supported way is to
use `dfx identity import --storage-mode=plaintext --force` and to set
`DFX_WARNING=-mainnet_plaintext_identity` (same pattern that the existing
`runtime-extension-deploy.yml` and `manual-agent-swarm.yml` workflows use).

This patch updates the three reusable workflows.

## Test plan

- [ ] PR CI (`ci-pr.yml`) green (Phase A only).
- [ ] After merge, `ci-main.yml` Phase B reaches `dfx canister create realm_installer --network staging` successfully.

Made with [Cursor](https://cursor.com)