### PR TITLE
ci: per-network install mode (upgrade for staging, reinstall for local)

### DIFF
--- a/deployments/local-mundus.yml
+++ b/deployments/local-mundus.yml
@@ -35,6 +35,11 @@
 version: 2
 network: local
 
+# Local CI starts on a fresh ephemeral replica every run, so every
+# canister is empty when stage 2 runs — the only legal install mode is
+# 'reinstall' (== install, since there's nothing to upgrade).
+install_mode: reinstall
+
 # --- Stage 1: artifacts to publish to file_registry --------------------------
 artifacts:
   base_wasm:

--- a/scripts/ci_install_mundus.py
+++ b/scripts/ci_install_mundus.py
@@ -275,6 +275,13 @@ def stage2_install(descriptor: Dict[str, Any], infra_ids: Dict[str, str]) -> Non
     base_version = (artifacts.get("base_wasm") or {}).get("version") or "0.0.0-dev"
     file_registry = infra_ids["file_registry"]
     realm_installer = infra_ids["realm_installer"]
+    # Default install mode: 'upgrade' preserves stable storage (admin
+    # permissions, user data, codex registrations) on already-installed
+    # canisters — correct for staging/ic where we redeploy on every push
+    # to main without wiping the world. The local descriptor sets
+    # `install_mode: reinstall` because every CI run starts on a fresh
+    # ephemeral replica where there's nothing to upgrade.
+    default_mode = (descriptor.get("install_mode") or "upgrade").strip()
 
     print("\n┌─ stage 2: install mundus members " + "─" * 32)
 
@@ -285,7 +292,8 @@ def stage2_install(descriptor: Dict[str, Any], infra_ids: Dict[str, str]) -> Non
             _dfx("canister", "create", name, network=network)
             canister_id = _canister_id(name, network)
 
-        print(f"\n   ▸ {name} ({canister_id})")
+        member_mode = (member.get("install_mode") or default_mode).strip()
+        print(f"\n   ▸ {name} ({canister_id})  [mode={member_mode}]")
         _add_controller(canister_id, realm_installer, network)
 
         # Install (or upgrade) the WASM via realm_installer.
@@ -296,7 +304,7 @@ def stage2_install(descriptor: Dict[str, Any], infra_ids: Dict[str, str]) -> Non
             "--installer", realm_installer,
             "--registry", file_registry,
             "--network", network,
-            "--mode", "reinstall",
+            "--mode", member_mode,
         ], capture_output=True)
         # realms wasm install exits 0 even when the underlying installer
         # canister returns success=false — surface that here so the


### PR DESCRIPTION
## Summary

Stage 2 (install-mundus) on staging was now passing the WASM install for
both \`realm_registry_backend\` and \`dominion\`, but failing the very
next call:

> Error in async method 'install_codex_from_registry': AccessDenied: user ah6ac-cc73l-…-2ae lacks permission 'codex.install'

Root cause: the orchestrator was unconditionally using \`--mode reinstall\`
for every member on every network. Reinstall wipes stable storage,
including the admin permissions table — so the codex install in the very
next step finds nobody is admin anymore and traps.

This patch:

1. Adds an \`install_mode\` field to the v2 mundus descriptor (root level
   default + optional per-member override).
2. Defaults to \`upgrade\` (preserves stable storage — the correct
   semantic for staging/ic where canisters are long-lived).
3. \`local-mundus.yml\` opts into \`reinstall\` because every PR CI run
   starts on a fresh ephemeral replica where canisters are empty.

## Test plan

- [ ] PR CI green (Phase A still uses reinstall).
- [ ] After merge, \`ci-main.yml\` Phase B reaches stage 4 (verify) on
      staging — i.e. all four mundus members upgrade cleanly and codex
      install succeeds.

Made with [Cursor](https://cursor.com)