### PR TITLE
ci(staging): don't re-register codices on every push

### DIFF
--- a/deployments/staging-mundus-layered.yml
+++ b/deployments/staging-mundus-layered.yml
@@ -38,26 +38,30 @@ mundus:
     extensions: []
     codices: []
 
+  # Codex installation is an admin-bound, one-time operation per realm —
+  # not something CI should re-run on every push. Stage 1 still publishes
+  # all codices to file_registry; admins install them once via the realms
+  # CLI / file_registry UI. CI refreshes base WASM + extensions only.
   - name: dominion
     type: realm
     canister_id: ijdaw-dyaaa-aaaac-beh2a-cai
     manifest: examples/demo/realm1/manifest.json
     extensions: inherit_from_artifacts
-    codices: [dominion]
+    codices: []
 
   - name: agora
     type: realm
     canister_id: ihbn6-yiaaa-aaaac-beh3a-cai
     manifest: examples/demo/realm2/manifest.json
     extensions: inherit_from_artifacts
-    codices: [agora]
+    codices: []
 
   - name: syntropia
     type: realm
     canister_id: jnope-2yaaa-aaaac-beh4a-cai
     manifest: examples/demo/realm3/manifest.json
     extensions: inherit_from_artifacts
-    codices: [syntropia]
+    codices: []
 
 verify:
   e2e_specs:


### PR DESCRIPTION
## Summary

Stage 2 still failed on staging (after PR #174 fixed the install mode):

> AccessDenied: user ah6ac-cc73l-…-2ae lacks permission 'codex.install'

The CI principal is intentionally **not** an admin of the long-lived
staging realms — only the realm operator is. Codex registration is an
admin-bound, one-time setup operation per realm, not a per-push CI
concern. Stage 1 still publishes every codex to file_registry on every
run; the canister-side install_codex call is a separate admin workflow
that runs out of band.

This patch sets \`codices: []\` on every staging mundus member so CI
focuses on what it should refresh (base WASM + extensions) without
trapping on permission checks.

## Test plan

- [ ] PR CI green.
- [ ] After merge, \`ci-main.yml\` Phase B reaches stage 4 (verify) on staging.

Made with [Cursor](https://cursor.com)