### PR TITLE
ci(staging): fix test paths and npm peer-deps for verify stage

### DIFF
--- a/.github/workflows/_verify-mundus.yml
+++ b/.github/workflows/_verify-mundus.yml
@@ -65,7 +65,9 @@ jobs:
       - name: Install Playwright + project deps
         working-directory: src/realm_frontend
         run: |
-          npm ci
+          # --legacy-peer-deps: svelte-markdown@0.4.1 declares a peer
+          # range that doesn't intersect the svelte version we pin.
+          npm ci --legacy-peer-deps
           npx playwright install --with-deps chromium
       - name: Run spec ${{ matrix.spec }}
         working-directory: src/realm_frontend

--- a/deployments/staging-mundus-layered.yml
+++ b/deployments/staging-mundus-layered.yml
@@ -65,8 +65,8 @@ mundus:
 
 verify:
   e2e_specs:
-    - src/realm_frontend/tests/e2e/specs/layered-parity.spec.ts
+    - tests/e2e/specs/layered-parity.spec.ts
   integration_tests:
-    - tests/backend/test_status_api.py
-    - tests/backend/test_extensions_api.py
+    - tests/integration/test_status_api.py
+    - tests/integration/test_extensions_api.py
     - tests/backend/test_realm_registry.py


### PR DESCRIPTION
## Summary

After PR #175 landed, the staging pipeline ran end-to-end for the first
time:

- ✅ bootstrap-infra-staging
- ✅ publish-artifacts-staging (base WASM + 20 extensions + codices to file_registry)
- ✅ install-mundus-staging (4 mundus members upgraded + extensions installed)
- ❌ verify-mundus-staging — 3 of 4 sub-jobs failed for unrelated reasons:
  - Two integration test paths pointed to non-existent files
    (\`tests/backend/test_status_api.py\`, \`tests/backend/test_extensions_api.py\`)
    when they actually live under \`tests/integration/\`.
  - The e2e spec path was repo-absolute, but the workflow does
    \`working-directory: src/realm_frontend && npx playwright test <spec>\`,
    so the path must be relative to that working directory.
  - \`npm ci\` failed with \`Conflicting peer dependency: svelte@4.2.20\`
    because \`svelte-markdown@0.4.1\` declares a peer range that doesn't
    intersect the svelte version we pin.

This patch fixes all three. After it lands, \`ci-main.yml\` should be
fully green end-to-end on staging.

## Test plan

- [ ] PR CI (Phase A) green.
- [ ] After merge, every job in \`ci-main.yml\` Phase B passes.

Made with [Cursor](https://cursor.com)