### PR TITLE
ci(e2e): fix __dirname in ESM scope in layered-parity spec

### DIFF
--- a/src/realm_frontend/tests/e2e/specs/layered-parity.spec.ts
+++ b/src/realm_frontend/tests/e2e/specs/layered-parity.spec.ts
@@ -1,6 +1,12 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { test, expect, type Page } from '@playwright/test';
+
+// __dirname is not defined in ESM scope (Playwright loads .spec.ts as ESM
+// when "type": "module" is in package.json or via tsconfig). Derive it.
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 /**
  * Layered Realm parity snapshots — Issue #168.


### PR DESCRIPTION
The spec loads as ESM under Playwright on the GH runner, where
\`__dirname\` is undefined. The module fails at import time:

\`\`\`
ReferenceError: __dirname is not defined in ES module scope
  at specs/layered-parity.spec.ts:79
\`\`\`

Derive \`__dirname\` from \`import.meta.url\`. Without this the test
never reaches the \`PLAYWRIGHT_BASE_URL\` skip check and the job
fails with "No tests found".

After this lands, the spec will load, find no tests it can run
(because \`PLAYWRIGHT_BASE_URL\` is intentionally not set in the
verify workflow yet — staging baselines aren't committed), and the
job will pass. Hooking up an actual baseline run and committing
snapshots is a follow-up.

Made with [Cursor](https://cursor.com)