### PR TITLE
fix(layered): install all 20 extensions + register realms with registry

### DIFF
--- a/deployments/staging-mundus-layered.yml
+++ b/deployments/staging-mundus-layered.yml
@@ -44,24 +44,33 @@ mundus:
   # CLI / file_registry UI. CI refreshes base WASM + extensions only.
   - name: dominion
     type: realm
+    display_name: Dominion
     canister_id: ijdaw-dyaaa-aaaac-beh2a-cai
+    frontend_canister_id: iocgc-oaaaa-aaaac-beh2q-cai
     manifest: examples/demo/realm1/manifest.json
     extensions: inherit_from_artifacts
     codices: []
+    register_with_registry: true
 
   - name: agora
     type: realm
+    display_name: Agora
     canister_id: ihbn6-yiaaa-aaaac-beh3a-cai
+    frontend_canister_id: iaalk-vqaaa-aaaac-beh3q-cai
     manifest: examples/demo/realm2/manifest.json
     extensions: inherit_from_artifacts
     codices: []
+    register_with_registry: true
 
   - name: syntropia
     type: realm
+    display_name: Syntropia
     canister_id: jnope-2yaaa-aaaac-beh4a-cai
+    frontend_canister_id: jkpjq-xaaaa-aaaac-beh4q-cai
     manifest: examples/demo/realm3/manifest.json
     extensions: inherit_from_artifacts
     codices: []
+    register_with_registry: true
 
 verify:
   e2e_specs:

--- a/scripts/ci_install_mundus.py
+++ b/scripts/ci_install_mundus.py
@@ -40,7 +40,12 @@ from typing import Any, Dict, List, Optional
 import yaml
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-EXTENSIONS_ROOT = REPO_ROOT / "extensions"
+# The realms-extensions submodule has a nested layout — manifests live at
+# `extensions/extensions/<name>/manifest.json` (the outer dir holds the
+# repo's README, marketplace/, etc.). publish_layered.py uses the same
+# inner directory; we must match it here, otherwise stage 2 silently
+# resolves "all extensions" to [] and never installs anything.
+EXTENSIONS_ROOT = REPO_ROOT / "extensions" / "extensions"
 CODICES_ROOT = REPO_ROOT / "codices" / "codices"
 
 
@@ -375,12 +380,83 @@ def _resolve_member_codices(member: Dict[str, Any], artifacts: Dict[str, Any]) -
     return list(spec or [])
 
 
+def _find_registry_member(descriptor: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Return the mundus member whose `type` is `realm_registry`, if any."""
+    for member in descriptor.get("mundus") or []:
+        if (member.get("type") or "").strip() == "realm_registry":
+            return member
+    return None
+
+
+def _frontend_url(canister_id: str, network: str) -> str:
+    if not canister_id:
+        return ""
+    if network == "ic":
+        return f"{canister_id}.ic0.app"
+    if network == "staging":
+        return f"{canister_id}.icp0.io"
+    return f"{canister_id}.localhost:8000"
+
+
+def _register_realm_with_registry(
+    member: Dict[str, Any],
+    registry_canister_id: str,
+    network: str,
+) -> None:
+    """Best-effort: tell a realm member to register itself with the registry.
+
+    Calls realm_backend.register_realm_with_registry from the CI principal.
+    Requires the CI principal to be either a controller of the realm
+    canister (covered by access._check_access ic.is_controller bypass) or
+    to hold the REALM_REGISTER permission. Any error is logged but
+    non-fatal — the realm can be registered manually after the fact.
+    """
+    name = member["name"]
+    canister_id = member["canister_id"]
+    realm_name = member.get("display_name") or name.title()
+    frontend_canister_id = (
+        member.get("frontend_canister_id")
+        or (member.get("canisters") or {}).get("frontend", "")
+    )
+    frontend_url = member.get("frontend_url") or _frontend_url(
+        frontend_canister_id, network
+    )
+    backend_url = member.get("backend_url") or _frontend_url(canister_id, network)
+    logo_url = member.get("logo_url", "")
+    canister_ids_packed = "|".join([
+        frontend_canister_id or "",
+        member.get("token_canister_id", ""),
+        member.get("nft_canister_id", ""),
+    ])
+    args = (
+        f'("{registry_canister_id}", "{realm_name}", "{frontend_url}", '
+        f'"{logo_url}", "{canister_ids_packed}")'
+    )
+    print(f"   • registering {name} with registry {registry_canister_id}")
+    try:
+        cp = subprocess.run(
+            ["dfx", "canister", "call", "--network", network,
+             canister_id, "register_realm_with_registry", args],
+            capture_output=True, text=True, check=True, timeout=120,
+        )
+        # The endpoint always returns a JSON string (success or error
+        # is inside it), even on canister-side failure paths.
+        print(f"     ↳ {cp.stdout.strip()[:300]}")
+    except subprocess.CalledProcessError as e:
+        print(
+            f"   ⚠️  failed to register {name}: {(e.stderr or e.stdout or '').strip()[:500]}"
+        )
+    except subprocess.TimeoutExpired:
+        print(f"   ⚠️  registration of {name} timed out after 120s")
+
+
 def stage2_install(descriptor: Dict[str, Any], infra_ids: Dict[str, str]) -> None:
     network = descriptor["network"]
     artifacts = descriptor.get("artifacts") or {}
     base_version = (artifacts.get("base_wasm") or {}).get("version") or "0.0.0-dev"
     file_registry = infra_ids["file_registry"]
     realm_installer = infra_ids["realm_installer"]
+    registry_member = _find_registry_member(descriptor)
     # Default install mode: 'upgrade' preserves stable storage (admin
     # permissions, user data, codex registrations) on already-installed
     # canisters — correct for staging/ic where we redeploy on every push
@@ -451,6 +527,22 @@ def stage2_install(descriptor: Dict[str, Any], infra_ids: Dict[str, str]) -> Non
                 "--registry", file_registry,
                 "--network", network,
             ])
+
+        # Register this realm with the central registry (best-effort,
+        # non-fatal). Only realm-type members that explicitly opt in
+        # via `register_with_registry: true` are registered, and only
+        # if the descriptor actually contains a registry member.
+        if (
+            (member.get("type") or "realm").strip() == "realm"
+            and bool(member.get("register_with_registry"))
+            and registry_member is not None
+        ):
+            _register_realm_with_registry(
+                member,
+                registry_member.get("canister_id")
+                or _canister_id(registry_member["name"], network) or "",
+                network,
+            )
 
     print("\n   ✅ mundus installed")
 

--- a/src/realm_backend/core/access.py
+++ b/src/realm_backend/core/access.py
@@ -46,7 +46,9 @@ def _check_access(caller_principal: str, operation: str) -> bool:
     """Check if a caller has permission to perform an operation.
 
     Resolution order:
-      0. Controller bypass (principal captured at init/post_upgrade)
+      0a. IC-level controller bypass (anyone in the canister settings'
+          controllers list — captured by the platform, not by us)
+      0b. Init-time controller bypass (principal captured at init/post_upgrade)
       1. Check trusted_principals on the Realm (canister-to-canister trust)
       2. Look up User by principal
       3. Check each of the user's profiles for the operation (coarse RBAC)
@@ -56,7 +58,21 @@ def _check_access(caller_principal: str, operation: str) -> bool:
 
     Returns True if allowed, False otherwise.
     """
-    # 0. Controller always allowed
+    # 0a. IC-level controllers always allowed. This is critical for
+    # layered deployments where realm_installer (a controller) drives
+    # post-install bootstrapping (registry registration, codex install,
+    # ...) and the deploying CI principal needs admin to bootstrap even
+    # though no explicit User record exists for it after a reinstall.
+    try:
+        if ic.is_controller(ic.caller()):
+            return True
+    except Exception:
+        # Older basilisk runtimes may not expose is_controller; the
+        # init-time _controller_principal fallback below still handles
+        # the original deployer in those cases.
+        pass
+
+    # 0b. First-deploy controller fallback (principal captured at init).
     if _controller_principal and caller_principal == _controller_principal:
         return True
 


### PR DESCRIPTION
## Summary

Three layered-deployment fixes that, together, make the staging realms (`dominion` / `agora` / `syntropia`) usable end-to-end after a CI run.

### 1. Extensions are now actually installed (the big one)

`scripts/ci_install_mundus.py`'s `EXTENSIONS_ROOT` was pointing at `realms/extensions/` but the `realms-extensions` submodule lays out manifests at `realms/extensions/extensions/<name>/manifest.json` (the outer dir holds README/marketplace/lint scripts). `publish_layered.py` already uses the inner directory; we have to match it here, otherwise:

- `_resolve_member_extensions(...)` calls `EXTENSIONS_ROOT.glob("*/manifest.json")`
- Glob matches nothing
- Stage 2 silently skips every `realms extension registry-install`

Result: file_registry had all 20 extensions published, but `list_runtime_extensions` on dominion returned `[]`. Verified locally that the corrected path discovers all 20.

### 2. Controllers can administer the realm

`realm_backend/core/access._check_access` only honored a single `_controller_principal` captured at init/post_upgrade. After a reinstall, the only `User` is the synthetic `system` user, so no real principal can call admin endpoints (`REALM_REGISTER`, `EXTENSION_INSTALL`, `CODEX_INSTALL`, …) — even with IC controller rights.

Added an `ic.is_controller(ic.caller())` bypass at the top of the resolution chain (mirroring what `file_registry/main.py` already does). Now CI's deploy principal — which is a controller of every realm — can bootstrap them.

### 3. CI registers each realm with the registry

Added a best-effort stage 2 step that calls `register_realm_with_registry` on any realm-type member with `register_with_registry: true`, when the descriptor includes a `realm_registry`-type member.

Opted `dominion`, `agora`, `syntropia` in (with their pinned frontend canister IDs) in `deployments/staging-mundus-layered.yml`, so every push to `main` re-registers them with the staging registry (`7wzxh-wyaaa-aaaau-aggyq-cai`).

## Test plan

- [ ] `ci-pr.yml` (local layered-e2e) passes.
- [ ] `ci-main.yml` (staging) passes; `list_runtime_extensions` on dominion returns 20 entries; `realm_count` on the registry returns 3.
- [ ] Browsing `https://iocgc-oaaaa-aaaac-beh2q-cai.icp0.io/` after merge shows the bundled-style sidebar back.

Made with [Cursor](https://cursor.com)