### PR TITLE
feat: package_manager extension + supporting frontend helpers

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -373,6 +373,24 @@ ls extensions/
 - Validate configuration: `realms validate`
 - Use dry-run mode: `realms realm deploy --dry-run`
 
+## GUI alternative: the Package Manager extension
+
+Most extension and codex management actions exposed by this CLI
+(`realms extension registry-install`, `realms extension runtime-install`,
+`realms extension runtime-uninstall`, `realms codex install`, ...) are
+also available to realm administrators directly from the realm's
+frontend, via the `package_manager` extension.
+
+The extension provides three tabs (Installed / Browse / Upload) wired
+to the same `install_extension*` / `install_codex*` /
+`uninstall_extension` / `uninstall_codex` backend endpoints used by this
+CLI. Once a realm has the package_manager extension installed, an admin
+no longer needs CLI access to the host machine to add or remove
+packages — they can do everything through the browser.
+
+See `docs/reference/EXTENSION_ARCHITECTURE.md → Package Manager Extension`
+for the full feature list, permissions model and caveats.
+
 ## Contributing
 
 1. Fork the repository

--- a/docs/reference/EXTENSION_ARCHITECTURE.md
+++ b/docs/reference/EXTENSION_ARCHITECTURE.md
@@ -418,3 +418,66 @@ graph LR
 - **Manifest validation**: CLI validates extension structure
 - **Sandboxed execution**: Extensions run in canister environment
 - **Input validation**: JSON schema validation for API calls
+
+## Package Manager Extension
+
+Realm administrators can install, update and uninstall both runtime
+extensions and codex packages directly from the realm's frontend, without
+re-deploying the WASM, by using the `package_manager` extension shipped
+under `extensions/extensions/package_manager/`.
+
+### What it does
+
+The extension is an admin-only sidebar entry (profiles: `["admin"]`,
+category: `other`) that wraps the existing realm_backend endpoints into
+a three-tab UI:
+
+| Tab        | What it does                                                                 | Backend calls                                                                 |
+|------------|-------------------------------------------------------------------------------|--------------------------------------------------------------------------------|
+| Installed  | Lists every runtime extension and codex package currently installed on the realm. Marks rows that have a newer version available in a connected registry. Offers Update / Reload (codex) / Uninstall. | `list_runtime_extensions`, `list_codex_packages`, `uninstall_extension`, `uninstall_codex`, `reload_codex`, plus `install_extension_from_registry` / `install_codex_from_registry` for updates |
+| Browse     | For each `file_registry` canister this realm is linked to (`status().registries`), fetches `/api/extensions` and `/api/codices` and shows everything publishable. Cross-references with the installed list to show install / update buttons. | HTTP GET to `{registry}/api/extensions` + `{registry}/api/codices` (via `$lib/file-registry-client`), then `install_extension_from_registry` / `install_codex_from_registry` |
+| Upload     | Lets the admin pick a folder of files (using `<input webkitdirectory>`) and pushes them in a single update call. Useful for one-off installs or local dev. Warns when the total payload exceeds the ~1.8 MB ICP ingress safe limit. | `install_extension({extension_id, files})` or `install_codex({codex_id, files, run_init})` |
+
+### Permissions
+
+All four mutating endpoints are gated by either `Operations.EXTENSION_INSTALL`
+/ `Operations.EXTENSION_UNINSTALL` or `Operations.CODEX_INSTALL` /
+`Operations.CODEX_UNINSTALL`. The default `ADMIN` profile (`Profiles.ADMIN`
+in `src/realm_backend/ggg/system/user_profile.py`) is granted
+`Operations.ALL` and therefore passes those checks. No new role wiring is
+required for the package manager to work.
+
+If you want a finer-grained role (e.g. a "package manager" sub-admin who
+can install but not configure other parts of the realm), grant
+`EXTENSION_INSTALL`, `EXTENSION_UNINSTALL`, `CODEX_INSTALL`, and
+`CODEX_UNINSTALL` to a custom profile in `Profiles`.
+
+### Sidebar live-reload
+
+After every successful install / uninstall the extension dispatches a
+`window` event (`realms:extensions-changed`). `Sidebar.svelte` listens for
+this event and re-runs `get_sidebar_manifests()` so the new entry appears
+immediately, without a full page reload.
+
+### Caveats
+
+- **Hot-loading**: backend extensions reload via `_load_module(force=True)`
+  in `core/runtime_extensions.py`. Codex `init.py` runs synchronously inside
+  the install update call, so a buggy `init.py` surfaces as the install
+  response — the UI displays the `init_warning` field returned by the
+  install call.
+- **Frontend bundle**: a runtime extension's compiled UI is fetched from
+  the file_registry the extension was installed from
+  (see `extension-loader.ts`). After install the extension routes are
+  available immediately, but the user may need to navigate to the new
+  sidebar entry to mount the bundle.
+- **Trust**: an admin can install arbitrary code from any registry the
+  realm is linked to. There is no signature/checksum verification step in
+  the runtime install path; if you need a "trusted publishers" gate, add
+  it on top of `install_extension_from_registry` (the registry has an ACL
+  for *publishing*, not for *consuming*).
+- **Ingress limits**: ICP update calls have a ~2 MB ingress limit. The
+  Upload tab warns when the total payload exceeds ~1.8 MB; for larger
+  payloads, publish the extension to a `file_registry` and use the Browse
+  tab instead — the registry-pull path uses inter-canister calls and
+  isn't subject to the same limit.

--- a/src/realm_frontend/src/lib/file-registry-client.ts
+++ b/src/realm_frontend/src/lib/file-registry-client.ts
@@ -1,0 +1,89 @@
+/**
+ * Lightweight HTTP client for talking to a `file_registry` canister from
+ * the realm_frontend.
+ *
+ * Why HTTP and not candid? The file_registry canister exposes both:
+ *   - candid query methods: list_extensions / list_codices / latest_version /
+ *     get_extension_manifest (see src/file_registry/main.py)
+ *   - HTTP routes: GET /api/extensions, GET /api/codices, GET /{namespace}/{path}
+ *     (handled by `_handle_http` in the same file)
+ *
+ * The HTTP route is preferred here because:
+ *   1. It works for any registry the realm is linked to without the
+ *      realm_frontend having to bake every registry's candid actor into
+ *      its bundle (the realm_frontend only ships the realm_backend actor).
+ *   2. It re-uses the same URL scheme as `extension-loader.ts` —
+ *      one helper (`fileRegistryBaseUrlFor`) covers both runtime bundle
+ *      loading and registry browsing.
+ *   3. The registry already adds permissive CORS headers in
+ *      `_http_response`, so the browser can read the response directly.
+ */
+import { fileRegistryBaseUrlFor } from '$lib/extension-loader';
+
+export interface RegistryExtension {
+  ext_id: string;
+  versions: string[];
+  latest: string;
+  manifest: Record<string, unknown> | null;
+}
+
+export interface RegistryCodex {
+  codex_id: string;
+  versions: string[];
+  latest: string;
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const resp = await fetch(url, { headers: { Accept: 'application/json' } });
+  if (!resp.ok) {
+    throw new Error(`HTTP ${resp.status} from ${url}: ${await resp.text().catch(() => '')}`);
+  }
+  return (await resp.json()) as T;
+}
+
+/**
+ * List every extension published in the given file_registry canister.
+ * Returns the same shape as the candid `list_extensions` query.
+ */
+export async function listRegistryExtensions(
+  registryCanisterId: string,
+): Promise<RegistryExtension[]> {
+  const base = fileRegistryBaseUrlFor(registryCanisterId);
+  return fetchJson<RegistryExtension[]>(`${base}/api/extensions`);
+}
+
+/**
+ * List every codex package published in the given file_registry canister.
+ */
+export async function listRegistryCodices(
+  registryCanisterId: string,
+): Promise<RegistryCodex[]> {
+  const base = fileRegistryBaseUrlFor(registryCanisterId);
+  return fetchJson<RegistryCodex[]>(`${base}/api/codices`);
+}
+
+/**
+ * Compare two semver-ish version strings ("1.2.3", "0.1.0", "1.2.3-rc1").
+ * Returns a negative number if a < b, positive if a > b, 0 if equal.
+ *
+ * This is a deliberately simple comparator (matching `_parse_semver` on the
+ * registry side); pre-release tags compare lexically, which is enough for
+ * the package-manager UI's "is the installed version older than the
+ * registry's latest?" check.
+ */
+export function compareVersions(a: string, b: string): number {
+  const pa = a.split('-', 1)[0].split('.').map((n) => parseInt(n, 10) || 0);
+  const pb = b.split('-', 1)[0].split('.').map((n) => parseInt(n, 10) || 0);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const x = pa[i] ?? 0;
+    const y = pb[i] ?? 0;
+    if (x !== y) return x - y;
+  }
+  // Same numeric prefix → fall back to lexical comparison of full string
+  // so "1.0.0-rc1" < "1.0.0".
+  if (a === b) return 0;
+  return a < b ? -1 : 1;
+}
+
+export const _internal = { fetchJson };

--- a/src/realm_frontend/src/routes/(sidebar)/Sidebar.svelte
+++ b/src/realm_frontend/src/routes/(sidebar)/Sidebar.svelte
@@ -308,6 +308,22 @@
 
 	onMount(() => {
 		loadSidebarExtensions();
+		// Re-load when an extension is installed or uninstalled at runtime
+		// (e.g. via the package_manager extension), so the new entry appears
+		// without a full page reload. Components dispatch this event after
+		// a successful install_*/uninstall_* call.
+		const onChanged = () => {
+			console.log('[Sidebar] realms:extensions-changed → reloading manifests');
+			loadSidebarExtensions();
+		};
+		if (typeof window !== 'undefined') {
+			window.addEventListener('realms:extensions-changed', onChanged);
+		}
+		return () => {
+			if (typeof window !== 'undefined') {
+				window.removeEventListener('realms:extensions-changed', onChanged);
+			}
+		};
 	});
 	
 	/**

--- a/src/realm_frontend/tests/e2e/specs/package-manager.spec.ts
+++ b/src/realm_frontend/tests/e2e/specs/package-manager.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E coverage for the package_manager extension — admin UI for installing,
+ * updating and uninstalling runtime extensions and codex packages from the
+ * realm frontend.
+ *
+ * What this verifies (without requiring a fully wired admin login):
+ *   - The page renders and registers in the SvelteKit router under
+ *     `/extensions/package_manager` (i.e. the source extension was
+ *     installed into realm_frontend).
+ *   - The three tabs (Installed / Browse / Upload) are present.
+ *
+ * The richer install/uninstall round-trip (which requires an authenticated
+ * admin principal and a populated file_registry) is left to the existing
+ * `runtime-extension.spec.ts` infrastructure; this spec only asserts that
+ * the new UI is reachable and structurally correct.
+ */
+test.describe('Package Manager extension', () => {
+	test('renders the three tabs at /extensions/package_manager', async ({ page }) => {
+		test.setTimeout(30_000);
+
+		const consoleErrors: string[] = [];
+		page.on('console', (msg) => {
+			if (msg.type() === 'error') consoleErrors.push(msg.text());
+		});
+		page.on('pageerror', (err) => {
+			consoleErrors.push(err.message);
+		});
+
+		await page.goto('/extensions/package_manager', { waitUntil: 'domcontentloaded' });
+
+		// Title — comes from the en.json bundled with the extension.
+		await expect(
+			page.getByRole('heading', { name: /Package Manager/i }),
+		).toBeVisible({ timeout: 15_000 });
+
+		// All three tabs must be rendered. We use a regex match because
+		// translations may add extra whitespace / decorations.
+		await expect(page.getByRole('tab', { name: /Installed/i })).toBeVisible();
+		await expect(page.getByRole('tab', { name: /Browse/i })).toBeVisible();
+		await expect(page.getByRole('tab', { name: /Upload/i })).toBeVisible();
+
+		// No frontend regressions specific to this page (we ignore
+		// pre-existing svelte-i18n / network warnings).
+		const newPageErrors = consoleErrors.filter(
+			(e) => /package_manager|file-registry-client|PackageManager/.test(e),
+		);
+		expect(newPageErrors, 'no package-manager-specific console errors').toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary

Wires up the new admin-only `package_manager` extension (added in the
extensions submodule, see smart-social-contracts/realms-extensions#6)
and the small supporting changes in realm_frontend it needs.

The user-facing result: a realm administrator can now install, update
and uninstall runtime extensions and codex packages from the browser,
without re-deploying the WASM and without CLI access to the host
machine.

## Changes

- **`extensions` submodule bumped** to bring in the new
  `package_manager` extension (manifest, three-tab Svelte UI,
  i18n in en/es/zh-CN). Frontend-only — no `entry.py`.
- **`src/realm_frontend/src/lib/file-registry-client.ts`** — new HTTP
  client for the file_registry canister's `/api/extensions` and
  `/api/codices` routes, sitting next to `extension-loader.ts` so both
  runtime bundle loading and registry browsing share the same URL
  convention.
- **`src/realm_frontend/src/routes/(sidebar)/Sidebar.svelte`** — listens
  for the `realms:extensions-changed` window event so the sidebar
  re-runs `get_sidebar_manifests()` immediately after a package is
  installed or uninstalled.
- **`src/realm_frontend/tests/e2e/specs/package-manager.spec.ts`** — new
  Playwright spec verifying the route renders with its three tabs.
- **`docs/reference/EXTENSION_ARCHITECTURE.md`** — new "Package Manager
  Extension" section describing the feature, permissions and caveats.
- **`cli/README.md`** — short pointer from the CLI docs to the GUI
  alternative.

## Permissions

All four mutating endpoints (`install_extension`, `uninstall_extension`,
`install_codex`, `uninstall_codex`, plus the `_from_registry` variants)
are already gated by `Operations.EXTENSION_INSTALL` /
`Operations.CODEX_INSTALL` in `src/realm_backend/main.py`. The default
`ADMIN` profile is granted `Operations.ALL` and therefore passes those
checks. No new role plumbing is needed.

## Out of scope

- The realm_backend already exposes everything the UI needs; no backend
  changes were required.
- Signature/checksum verification of registry contents is intentionally
  not added in this PR — the registry has an ACL for *publishing* but
  not for *consuming*. If/when a "trusted publishers" gate is needed,
  it can be layered on top of `install_extension_from_registry`.

## Test plan

- [ ] `realms extension install-from-source --source-dir extensions`
      succeeds and `/extensions/package_manager` route appears.
- [ ] As an admin, the sidebar shows the new "Package Manager" entry.
- [ ] Installed tab lists currently installed runtime extensions /
      codices (from `list_runtime_extensions` / `list_codex_packages`).
- [ ] Browse tab lists packages from each linked file_registry
      (verified via the Settings page's registries list).
- [ ] Install round-trip: install a registry-published extension,
      confirm it appears in the sidebar without a reload, then
      uninstall it.
- [ ] Upload tab installs an extension from a chosen folder under the
      ~1.8 MB warning threshold.
- [ ] `package-manager.spec.ts` passes in CI.

Made with [Cursor](https://cursor.com)