### PR TITLE
ci: add Fast deploy (staging) workflow for prototyping

### DIFF
--- a/.github/workflows/fast-deploy-staging.yml
+++ b/.github/workflows/fast-deploy-staging.yml
@@ -119,22 +119,28 @@ jobs:
           echo "🆔 Identity:      $(dfx identity get-principal)"
 
       - name: Run stages 1 + 2 against ${{ inputs.descriptor }}
+        env:
+          # Surface descriptor + filter inputs as plain env vars so the
+          # bash below can quote them safely without going through GHA
+          # `${{ ... }}` expansion inside `if`/`set --` (which trips
+          # shellcheck SC2054 about commas inside array literals).
+          DESCRIPTOR: ${{ inputs.descriptor }}
+          ONLY_REALMS: ${{ inputs.realms }}
+          ONLY_EXTENSIONS: ${{ inputs.extensions }}
+          SKIP_BASE_WASM: ${{ inputs.skip_base_wasm }}
         run: |
-          ARGS=(
-            --file "${{ inputs.descriptor }}"
-            --stages 1,2
-          )
-          if [ -n "${{ inputs.realms }}" ]; then
-            ARGS+=( --only-realms "${{ inputs.realms }}" )
+          set -- --file "$DESCRIPTOR" --stages 1,2
+          if [ -n "$ONLY_REALMS" ]; then
+            set -- "$@" --only-realms "$ONLY_REALMS"
           fi
-          if [ -n "${{ inputs.extensions }}" ]; then
-            ARGS+=( --only-extensions "${{ inputs.extensions }}" )
+          if [ -n "$ONLY_EXTENSIONS" ]; then
+            set -- "$@" --only-extensions "$ONLY_EXTENSIONS"
           fi
-          if [ "${{ inputs.skip_base_wasm }}" = "true" ]; then
-            ARGS+=( --skip-base-wasm )
+          if [ "$SKIP_BASE_WASM" = "true" ]; then
+            set -- "$@" --skip-base-wasm
           fi
-          echo "→ python3 scripts/ci_install_mundus.py ${ARGS[*]}"
-          python3 scripts/ci_install_mundus.py "${ARGS[@]}"
+          echo "→ python3 scripts/ci_install_mundus.py $*"
+          python3 scripts/ci_install_mundus.py "$@"
 
       - name: Print frontend URLs
         if: success()

--- a/.github/workflows/fast-deploy-staging.yml
+++ b/.github/workflows/fast-deploy-staging.yml
@@ -1,0 +1,153 @@
+# fast-deploy-staging.yml — manual, fast staging deploy for prototyping.
+#
+# A "see it now" path that runs in PARALLEL to ci-main.yml. Trade-offs:
+#   * Skips Phase A (no local-replica e2e gating).
+#   * Skips stage 0 (staging infra is long-lived).
+#   * Skips stage 4 (no Playwright / no integration tests at the end).
+#   * Collapses stage 1 (publish) + stage 2 (install) into ONE job, so we
+#     pay the runner cold-start tax (checkout submodules, install dfx,
+#     install Node + Python deps) only once instead of three times.
+#   * Optional `realms` / `extensions` filters trim what gets built and
+#     installed, so a frontend-only iteration on a single realm becomes
+#     ~3-5 minutes instead of ~50.
+#
+# Use the regular `CI (main)` pipeline for anything that should be gated
+# by tests before reaching staging. This workflow is a developer tool —
+# not a release pipeline.
+
+name: Fast deploy (staging)
+
+on:
+  workflow_dispatch:
+    inputs:
+      descriptor:
+        description: "Mundus descriptor to deploy"
+        required: true
+        type: choice
+        default: deployments/staging-mundus-layered.yml
+        options:
+          - deployments/staging-mundus-layered.yml
+          - deployments/demo-mundus-layered.yml
+
+      realms:
+        description: "Comma-separated mundus member names to (re)deploy. Leave empty for all (e.g. 'dominion' or 'dominion,agora')."
+        required: false
+        default: ""
+
+      extensions:
+        description: "Comma-separated extension ids to publish + install. Leave empty for all (e.g. 'package_manager,admin_dashboard')."
+        required: false
+        default: ""
+
+      skip_base_wasm:
+        description: "Skip rebuilding+publishing realm_backend.wasm.gz. Tick this for frontend/extension-only iteration."
+        required: false
+        type: boolean
+        default: false
+
+      ref:
+        description: "realms commit/branch to deploy from (defaults to the workflow ref)."
+        required: false
+        default: ""
+
+concurrency:
+  # Different group from `ci-main` so this can run in parallel with the
+  # main pipeline. Self-serializing per-descriptor so two parallel fast-
+  # deploys against the same descriptor don't race.
+  group: fast-deploy-${{ inputs.descriptor }}
+  cancel-in-progress: false
+
+env:
+  PYTHON_VERSION: "3.10"
+  NODE_VERSION: "20"
+  DFX_VERSION: "0.31.0"
+
+jobs:
+  fast-deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          ref: ${{ inputs.ref || github.ref }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install dfx ${{ env.DFX_VERSION }}
+        run: |
+          DFXVM_INIT_YES=1 sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)"
+          echo "$HOME/.local/share/dfx/bin" >> "$GITHUB_PATH"
+
+      - name: Install realms CLI + Python deps
+        run: |
+          pip install -e cli/
+          pip install pyyaml
+
+      - name: Configure dfx identity
+        env:
+          IC_IDENTITY_PEM: ${{ secrets.IC_IDENTITY_PEM }}
+        run: |
+          if [ -z "$IC_IDENTITY_PEM" ]; then
+            echo "::error::IC_IDENTITY_PEM secret is not set on this repo." >&2
+            exit 1
+          fi
+          printf '%s' "$IC_IDENTITY_PEM" > /tmp/identity.pem
+          chmod 600 /tmp/identity.pem
+          dfx identity import ci /tmp/identity.pem --storage-mode=plaintext --force
+          dfx identity use ci
+          rm -f /tmp/identity.pem
+          echo "DFX_WARNING=-mainnet_plaintext_identity" >> "$GITHUB_ENV"
+
+      - name: Print run parameters
+        run: |
+          echo "╭────────────────────────────────────────╮"
+          echo "│ ⚡ Fast deploy (staging)                │"
+          echo "╰────────────────────────────────────────╯"
+          echo "📄 Descriptor:    ${{ inputs.descriptor }}"
+          echo "🏛️  Realms:        ${{ inputs.realms || '(all)' }}"
+          echo "🧩 Extensions:    ${{ inputs.extensions || '(all from descriptor)' }}"
+          echo "⏭  skip_base_wasm: ${{ inputs.skip_base_wasm }}"
+          echo "🔀 Ref:           ${{ inputs.ref || github.ref }}"
+          echo "🆔 Identity:      $(dfx identity get-principal)"
+
+      - name: Run stages 1 + 2 against ${{ inputs.descriptor }}
+        run: |
+          ARGS=(
+            --file "${{ inputs.descriptor }}"
+            --stages 1,2
+          )
+          if [ -n "${{ inputs.realms }}" ]; then
+            ARGS+=( --only-realms "${{ inputs.realms }}" )
+          fi
+          if [ -n "${{ inputs.extensions }}" ]; then
+            ARGS+=( --only-extensions "${{ inputs.extensions }}" )
+          fi
+          if [ "${{ inputs.skip_base_wasm }}" = "true" ]; then
+            ARGS+=( --skip-base-wasm )
+          fi
+          echo "→ python3 scripts/ci_install_mundus.py ${ARGS[*]}"
+          python3 scripts/ci_install_mundus.py "${ARGS[@]}"
+
+      - name: Print frontend URLs
+        if: success()
+        run: |
+          python3 - <<'PY'
+          import os, yaml
+          desc = yaml.safe_load(open(os.environ["DESC"]))
+          print()
+          print("✅ Fast deploy complete. Live frontends:")
+          for m in desc.get("mundus", []):
+              fe = m.get("frontend_canister_id")
+              if fe:
+                  print(f"   • {m.get('display_name') or m['name']:14s} → https://{fe}.icp0.io/")
+          PY
+        env:
+          DESC: ${{ inputs.descriptor }}

--- a/scripts/ci_install_mundus.py
+++ b/scripts/ci_install_mundus.py
@@ -589,10 +589,57 @@ def main(argv: Optional[List[str]] = None) -> int:
                         help="Comma-separated stages to run (default: 0,1,2,3)")
     parser.add_argument("--infra-ids-out", type=Path, default=None,
                         help="Write resolved infra canister ids as JSON for downstream jobs")
+    parser.add_argument("--only-realms", default=None,
+                        help="Comma-separated mundus member names. When set, "
+                             "stages 1+2+3 only consider these members "
+                             "(e.g. 'dominion,realm_registry_backend').")
+    parser.add_argument("--only-extensions", default=None,
+                        help="Comma-separated extension ids. When set, "
+                             "stage 1 publishes only these extensions and "
+                             "stage 2 installs only these on each member that "
+                             "would otherwise inherit_from_artifacts=all.")
+    parser.add_argument("--skip-base-wasm", action="store_true",
+                        help="Skip building+publishing the realm_backend "
+                             "(base) WASM in stage 1. Useful when iterating "
+                             "on frontend/extensions only.")
     args = parser.parse_args(argv)
 
     stages = {int(s) for s in args.stages.split(",") if s}
     descriptor = load_descriptor(args.file)
+
+    only_realms = (
+        [r.strip() for r in args.only_realms.split(",") if r.strip()]
+        if args.only_realms else None
+    )
+    if only_realms:
+        members = descriptor.get("mundus") or []
+        names = {m.get("name") for m in members}
+        unknown = [r for r in only_realms if r not in names]
+        if unknown:
+            raise SystemExit(
+                f"--only-realms contains unknown member(s): {unknown}. "
+                f"Known: {sorted(n for n in names if n)}"
+            )
+        descriptor["mundus"] = [m for m in members if m.get("name") in only_realms]
+        print(f"🎯 only-realms : {only_realms}")
+
+    only_exts = (
+        [e.strip() for e in args.only_extensions.split(",") if e.strip()]
+        if args.only_extensions else None
+    )
+    if only_exts:
+        descriptor.setdefault("artifacts", {})["extensions"] = list(only_exts)
+        # Replace `inherit_from_artifacts` / `all` on each member so stage 2
+        # actually narrows the install set too (otherwise it would still
+        # try to install every extension on disk).
+        for m in descriptor.get("mundus") or []:
+            if m.get("extensions") in (None, "all", "inherit_from_artifacts"):
+                m["extensions"] = list(only_exts)
+        print(f"🎯 only-extensions: {only_exts}")
+
+    if args.skip_base_wasm:
+        descriptor.setdefault("artifacts", {}).setdefault("base_wasm", {})["skip"] = True
+        print("⏭  skip-base-wasm: realm_backend WASM build will be skipped")
 
     print(f"📄 descriptor : {args.file}")
     print(f"📡 network    : {descriptor['network']}")


### PR DESCRIPTION
## Summary

Adds a manually-triggered **Fast deploy (staging)** workflow as a "see it now"
path that runs **in parallel** to `CI (main)`. Cuts iteration time from
~50 min to ~5–15 min depending on scope.

## Why

`CI (main)` is great for releases but painful for prototyping:

| Phase | Job | Cost |
| --- | --- | --- |
| A | `layered-e2e-local` (full local install + tests) | ~10 min — pure gate, deploys nothing |
| B | `bootstrap-infra-staging` → `publish` → `install` → `verify` (4 sequential reusable workflows) | ~40 min — each new job pays a 2-3 min cold-start tax (checkout submodules, install dfx, install Node + Python deps) |
|   | `concurrency.group: ci-main` with `cancel-in-progress: false` | serializes pushes, so the second push waits for the first to finish |

## What this adds

### `.github/workflows/fast-deploy-staging.yml`

Single-job workflow_dispatch with these inputs:

- `descriptor` — `staging-mundus-layered.yml` (default) or `demo-mundus-layered.yml`
- `realms` — comma-separated subset (e.g. `dominion` or `dominion,agora`). Empty = all.
- `extensions` — comma-separated subset (e.g. `package_manager,admin_dashboard`). Empty = all.
- `skip_base_wasm` — boolean. Tick this for frontend-only iteration.
- `ref` — branch/SHA to deploy from (defaults to workflow ref).

Differences vs `CI (main)`:

- Skips Phase A (no local-replica e2e gating).
- Skips stage 0 (staging infra is long-lived, no need to re-verify).
- Skips stage 4 (no Playwright / no integration tests at the end).
- Collapses stage 1 (publish) + stage 2 (install) into ONE job — pays the runner cold-start tax once, not three times.
- `concurrency.group: fast-deploy-${{ inputs.descriptor }}` — different from `ci-main`, so the two pipelines can run side-by-side on the same push.
- Prints frontend URLs at the end so you can click straight through to the deployed realm.

### `scripts/ci_install_mundus.py`

Three new CLI flags so the workflow's filters actually narrow the work:

- `--only-realms <a,b>` — restrict the descriptor's mundus list. Errors with the list of valid names if you typo a realm.
- `--only-extensions <a,b>` — narrows stage 1's publish set AND replaces `inherit_from_artifacts=all` on each member, so stage 2 doesn't blindly install every extension on disk.
- `--skip-base-wasm` — sets `descriptor['artifacts']['base_wasm']['skip']=True`. Useful for iterating on extensions without rebuilding the realm_backend WASM.

All three flags are optional and orthogonal to existing usage — `CI (main)` keeps working unchanged.

## Typical usage

Frontend-only tweak to one realm (~3-5 min):

```
gh workflow run fast-deploy-staging.yml \
  -f realms=dominion \
  -f extensions=package_manager,admin_dashboard \
  -f skip_base_wasm=true
```

Backend-touching change to one realm (~10-15 min):

```
gh workflow run fast-deploy-staging.yml -f realms=dominion
```

Full staging redeploy without the gate (~20-25 min):

```
gh workflow run fast-deploy-staging.yml
```

## Test plan

- [x] `--help` shows the three new flags.
- [x] Filter parsing tested locally with all combinations + an unknown-realm error case (clean exit-1 with the list of valid names).
- [x] YAML parses; descriptor still loads with the new flags applied.
- [ ] Smoke-trigger `Fast deploy (staging)` after merge with `realms=dominion, extensions=package_manager,admin_dashboard, skip_base_wasm=true` and confirm Dominion shows the package_manager + Packages widget at https://iocgc-oaaaa-aaaac-beh2q-cai.icp0.io/.
- [ ] Trigger another fast-deploy while `CI (main)` is running on `main` to confirm they run in parallel (different concurrency groups).

Made with [Cursor](https://cursor.com)