### PR TITLE
fix(publish): resolve nested extensions/extensions/ layout, fail loud on empty

### DIFF
--- a/scripts/build_runtime_bundles.py
+++ b/scripts/build_runtime_bundles.py
@@ -47,8 +47,54 @@ SKIP_EXTENSION_IDS = {"_shared"}
 # Helpers
 # ---------------------------------------------------------------------------
 
+def _resolve_extensions_root(repo: Path) -> Path:
+    """Return the directory that holds per-extension subdirectories.
+
+    Mirrors ``scripts/publish_layered.py::_resolve_extensions_root``. The
+    ``realms-extensions`` submodule has a nested layout
+    (``<repo>/extensions/extensions/<name>/``); a standalone
+    ``realms-extensions`` checkout has a flat layout
+    (``<repo>/extensions/<name>/``). Try nested first, fall back to
+    flat. Fail loud if neither contains any extension dirs.
+
+    A "valid" candidate is a dir with at least one child that is itself
+    a dir (excluding ``_shared``) — even if that child has no
+    ``frontend-rt/`` (most don't). The frontend-rt presence check is
+    the caller's job; here we just resolve which dir to walk.
+    """
+    nested = repo / "extensions" / "extensions"
+    flat = repo / "extensions"
+
+    def _has_extension_dirs(candidate: Path) -> bool:
+        if not candidate.is_dir():
+            return False
+        for child in candidate.iterdir():
+            if not child.is_dir() or child.name in SKIP_EXTENSION_IDS:
+                continue
+            # An extension dir is one that has either a manifest.json
+            # (any kind of extension) or a frontend-rt/ (the only thing
+            # this script cares about). Either signal proves the layout.
+            if (child / "manifest.json").exists() or (
+                child / "frontend-rt" / "package.json"
+            ).exists():
+                return True
+        return False
+
+    if _has_extension_dirs(nested):
+        return nested
+    if _has_extension_dirs(flat):
+        return flat
+    raise SystemExit(
+        "ERROR: no extension directories found under either of:\n"
+        f"  {nested}  (nested realms+submodule layout)\n"
+        f"  {flat}  (standalone realms-extensions checkout layout)\n"
+        "Did the realms-extensions submodule fail to initialize? Try:\n"
+        "  git submodule update --init --recursive"
+    )
+
+
 def _list_rt_dirs(extensions_root: Path, only: Optional[List[str]]) -> List[Path]:
-    """Return every realms-extensions/extensions/<ext>/frontend-rt that has a package.json."""
+    """Return every <extensions_root>/<ext>/frontend-rt that has a package.json."""
     if not extensions_root.is_dir():
         raise FileNotFoundError(f"Extensions root not found: {extensions_root}")
     out: List[Path] = []
@@ -192,7 +238,9 @@ def main(argv: Iterable[str]) -> int:
         print(f"ERROR: npm binary not found in PATH: {args.npm}", file=sys.stderr)
         return 1
 
-    extensions_root = Path(args.extensions_repo).expanduser().resolve() / "extensions"
+    extensions_root = _resolve_extensions_root(
+        Path(args.extensions_repo).expanduser().resolve()
+    )
     only_list: Optional[List[str]] = None
     if args.only:
         only_list = [s.strip() for s in args.only.split(",") if s.strip()]
@@ -204,7 +252,19 @@ def main(argv: Iterable[str]) -> int:
         return 1
 
     if not rt_dirs:
-        print("No frontend-rt/ directories found to build.")
+        # It's legitimate for a repo to have extensions but none with a
+        # frontend-rt/ — that just means there's nothing to bundle. Don't
+        # fail loud here (unlike publish_layered._step_publish_extensions);
+        # the caller's `--only` filter may simply target an extension
+        # without a frontend-rt/. Just print and return success.
+        if only_list:
+            print(
+                f"No frontend-rt/ directories found under {extensions_root} "
+                f"matching --only={only_list}. Available with frontend-rt: "
+                f"{sorted(p.parent.name for p in _list_rt_dirs(extensions_root, None))}"
+            )
+        else:
+            print(f"No frontend-rt/ directories found to build under {extensions_root}.")
         return 0
 
     print(f"Building {len(rt_dirs)} runtime bundles from {extensions_root}")

--- a/scripts/ci_install_mundus.py
+++ b/scripts/ci_install_mundus.py
@@ -41,10 +41,18 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 # The realms-extensions submodule has a nested layout — manifests live at
-# `extensions/extensions/<name>/manifest.json` (the outer dir holds the
-# repo's README, marketplace/, etc.). publish_layered.py uses the same
-# inner directory; we must match it here, otherwise stage 2 silently
-# resolves "all extensions" to [] and never installs anything.
+# `extensions/extensions/<name>/manifest.json` (the outer dir is the
+# submodule root and holds the repo's README, marketplace/, testing/,
+# etc., which would otherwise be iterated as if they were extensions).
+#
+# publish_layered.py and build_runtime_bundles.py go through their own
+# `_resolve_extensions_root(repo)` helper which auto-detects either the
+# nested layout (this repo) or the flat layout (a standalone
+# realms-extensions checkout). We must match the *nested* path here
+# because stage 2 walks `EXTENSIONS_ROOT` directly when a member has
+# `extensions: all` — and getting that wrong used to silently resolve
+# "all extensions" to [] (root cause of issue: package_manager not
+# publishing on staging in the run for #183).
 EXTENSIONS_ROOT = REPO_ROOT / "extensions" / "extensions"
 CODICES_ROOT = REPO_ROOT / "codices" / "codices"
 

--- a/scripts/publish_layered.py
+++ b/scripts/publish_layered.py
@@ -84,6 +84,51 @@ def _run(cmd: List[str], cwd: Optional[Path] = None) -> int:
     return proc.returncode
 
 
+def _resolve_extensions_root(repo: Path) -> Path:
+    """Return the directory that holds per-extension subdirectories.
+
+    The ``realms-extensions`` submodule has a nested layout — extensions
+    live under ``<repo>/extensions/extensions/<name>/manifest.json`` (the
+    outer ``extensions/`` dir is the submodule root, which also contains
+    README.md, marketplace/, testing/, etc. and would otherwise be
+    iterated as if they were extensions).
+
+    But when this script is invoked against a *standalone* checkout of
+    the ``realms-extensions`` repo (the historical local-dev mode, e.g.
+    ``--extensions-repo ../realms-extensions``) the layout is flat:
+    ``<repo>/extensions/<name>/manifest.json``.
+
+    Try the nested layout first, fall back to the flat one. Fail loud
+    if neither contains any ``manifest.json`` — silently iterating an
+    empty dir and "publishing" zero extensions is exactly the bug that
+    let ``package_manager`` fail to install on staging in #183.
+    """
+    nested = repo / "extensions" / "extensions"
+    flat = repo / "extensions"
+
+    def _has_manifests(candidate: Path) -> bool:
+        if not candidate.is_dir():
+            return False
+        for child in candidate.iterdir():
+            if not child.is_dir() or child.name in SKIP_EXTENSION_IDS:
+                continue
+            if (child / "manifest.json").exists():
+                return True
+        return False
+
+    if _has_manifests(nested):
+        return nested
+    if _has_manifests(flat):
+        return flat
+    raise SystemExit(
+        "ERROR: no extension manifests found under either of:\n"
+        f"  {nested}  (nested realms+submodule layout)\n"
+        f"  {flat}  (standalone realms-extensions checkout layout)\n"
+        "Did the realms-extensions submodule fail to initialize? Try:\n"
+        "  git submodule update --init --recursive"
+    )
+
+
 def _list_extensions(extensions_root: Path, only: Optional[List[str]]) -> List[Path]:
     if not extensions_root.is_dir():
         raise FileNotFoundError(f"Extensions root not found: {extensions_root}")
@@ -306,10 +351,26 @@ def _step_publish_extensions(
     only: Optional[List[str]],
     namespace_prefix: str,
 ) -> int:
-    ext_dirs = _list_extensions(extensions_repo / "extensions", only)
+    ext_dirs = _list_extensions(_resolve_extensions_root(extensions_repo), only)
     if not ext_dirs:
-        print("No extensions to publish.")
-        return 0
+        # _resolve_extensions_root guarantees the dir has at least one
+        # manifest.json, so an empty `ext_dirs` here means the `--only`
+        # filter excluded everything. That's a user mistake, not an
+        # auto-recoverable no-op — fail loud.
+        if only:
+            raise SystemExit(
+                f"ERROR: --only-extensions={only} matched zero extensions "
+                f"under {_resolve_extensions_root(extensions_repo)}. "
+                "Available: "
+                f"{sorted(p.name for p in _resolve_extensions_root(extensions_repo).iterdir() if p.is_dir())}"
+            )
+        # Genuinely empty (no extensions at all) is also unexpected and
+        # would be silently ignored historically — surface it.
+        raise SystemExit(
+            "ERROR: zero extensions found. This used to silently succeed "
+            "and is the root cause of issue: package_manager not "
+            "publishing on staging."
+        )
     print(f"\nPublishing {len(ext_dirs)} extensions → {registry}:{namespace_prefix}/<id>/<ver>")
     failures: List[str] = []
     for ext_dir in ext_dirs:

--- a/tests/scripts/test_extensions_root_resolution.py
+++ b/tests/scripts/test_extensions_root_resolution.py
@@ -1,0 +1,155 @@
+"""Tests for ``_resolve_extensions_root`` in the layered-publish scripts.
+
+These exist because we discovered (when CI run #24599789350 on commit
+``1b77889`` failed to install ``package_manager`` on staging) that
+``scripts/publish_layered.py`` and ``scripts/build_runtime_bundles.py``
+were silently iterating the wrong directory and "publishing" zero
+extensions, then exiting 0. Stage 2 then crashed with
+``No versions found for ext/package_manager``.
+
+The fix is a ``_resolve_extensions_root(repo)`` helper in each script
+that auto-detects nested-vs-flat layouts and **fails loud** if neither
+contains any extension dirs. These tests pin that behavior.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add repo root + scripts/ to sys.path so we can import the scripts as
+# regular modules even though they're top-level scripts (not a package).
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import build_runtime_bundles as brb  # noqa: E402
+import publish_layered as pl  # noqa: E402
+
+
+def _make_ext(dir_path: Path, *, manifest: bool = True, frontend_rt: bool = False) -> None:
+    dir_path.mkdir(parents=True, exist_ok=True)
+    if manifest:
+        (dir_path / "manifest.json").write_text(json.dumps({"id": dir_path.name}))
+    if frontend_rt:
+        rt = dir_path / "frontend-rt"
+        rt.mkdir()
+        (rt / "package.json").write_text(json.dumps({"name": dir_path.name}))
+
+
+# ---------------------------------------------------------------------------
+# publish_layered._resolve_extensions_root
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_picks_nested_layout(tmp_path: Path) -> None:
+    """The realms-monorepo case: <repo>/extensions/extensions/<id>/manifest.json."""
+    _make_ext(tmp_path / "extensions" / "extensions" / "package_manager")
+    assert pl._resolve_extensions_root(tmp_path) == tmp_path / "extensions" / "extensions"
+
+
+def test_resolve_falls_back_to_flat_layout(tmp_path: Path) -> None:
+    """Standalone realms-extensions checkout: <repo>/extensions/<id>/manifest.json."""
+    _make_ext(tmp_path / "extensions" / "package_manager")
+    assert pl._resolve_extensions_root(tmp_path) == tmp_path / "extensions"
+
+
+def test_resolve_prefers_nested_when_both_present(tmp_path: Path) -> None:
+    """If both layouts somehow exist, the nested one wins (it's the real one
+    inside the realms repo and matches what ci_install_mundus.py walks)."""
+    _make_ext(tmp_path / "extensions" / "extensions" / "real_one")
+    _make_ext(tmp_path / "extensions" / "decoy")
+    assert pl._resolve_extensions_root(tmp_path) == tmp_path / "extensions" / "extensions"
+
+
+def test_resolve_fails_loud_when_no_manifests(tmp_path: Path) -> None:
+    """The bug we're fixing: an empty layout used to silently succeed."""
+    (tmp_path / "extensions" / "extensions").mkdir(parents=True)
+    (tmp_path / "extensions" / "README.md").write_text("hi")
+    with pytest.raises(SystemExit) as exc:
+        pl._resolve_extensions_root(tmp_path)
+    msg = str(exc.value)
+    assert "no extension manifests found" in msg
+    assert "submodule" in msg  # mentions the likely cause + remedy
+
+
+def test_resolve_ignores_shared_helper_dir(tmp_path: Path) -> None:
+    """A repo with only the ``_shared`` helper dir is effectively empty."""
+    (tmp_path / "extensions" / "extensions" / "_shared").mkdir(parents=True)
+    with pytest.raises(SystemExit):
+        pl._resolve_extensions_root(tmp_path)
+
+
+def test_resolve_ignores_marketplace_and_testing(tmp_path: Path) -> None:
+    """The submodule's own README/marketplace/testing dirs at ``extensions/``
+    must not trick the resolver into picking the flat layout."""
+    nested = tmp_path / "extensions" / "extensions"
+    nested.mkdir(parents=True)
+    # Outer-level decoys (these exist in the real submodule):
+    (tmp_path / "extensions" / "marketplace").mkdir()
+    (tmp_path / "extensions" / "testing").mkdir()
+    (tmp_path / "extensions" / "README.md").write_text("hi")
+    # No actual extensions ⇒ must fail, NOT pick `tmp_path/extensions`.
+    with pytest.raises(SystemExit):
+        pl._resolve_extensions_root(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# publish_layered._step_publish_extensions filter behavior
+# ---------------------------------------------------------------------------
+
+
+def test_publish_only_filter_with_unknown_id_fails_loud(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Passing --only-extensions=<typo> used to silently succeed too."""
+    _make_ext(tmp_path / "extensions" / "extensions" / "package_manager")
+
+    with pytest.raises(SystemExit) as exc:
+        pl._step_publish_extensions(
+            realms_cli=["realms"],
+            registry="rrkah-fqaaa-aaaaa-aaaaq-cai",  # ignored on this path
+            network="local",
+            identity=None,
+            extensions_repo=tmp_path,
+            only=["definitely_not_an_extension"],
+            namespace_prefix="ext",
+        )
+    msg = str(exc.value)
+    assert "matched zero extensions" in msg
+    assert "package_manager" in msg  # lists what *was* available
+
+
+# ---------------------------------------------------------------------------
+# build_runtime_bundles._resolve_extensions_root
+# ---------------------------------------------------------------------------
+
+
+def test_brb_resolve_picks_nested_via_frontend_rt(tmp_path: Path) -> None:
+    """build_runtime_bundles cares about frontend-rt presence, not manifest.json.
+
+    Some extensions ship only a manifest (no frontend-rt). The resolver
+    must still find the layout based on either signal.
+    """
+    _make_ext(tmp_path / "extensions" / "extensions" / "ext_a", frontend_rt=True)
+    assert brb._resolve_extensions_root(tmp_path) == tmp_path / "extensions" / "extensions"
+
+
+def test_brb_resolve_picks_nested_via_manifest_only(tmp_path: Path) -> None:
+    """An extension with only manifest.json (no frontend-rt) is still a valid
+    layout signal — the caller will just skip it during bundle building."""
+    _make_ext(tmp_path / "extensions" / "extensions" / "ext_a")  # manifest only
+    assert brb._resolve_extensions_root(tmp_path) == tmp_path / "extensions" / "extensions"
+
+
+def test_brb_resolve_falls_back_to_flat(tmp_path: Path) -> None:
+    _make_ext(tmp_path / "extensions" / "ext_a", frontend_rt=True)
+    assert brb._resolve_extensions_root(tmp_path) == tmp_path / "extensions"
+
+
+def test_brb_resolve_fails_loud_when_empty(tmp_path: Path) -> None:
+    (tmp_path / "extensions" / "extensions").mkdir(parents=True)
+    with pytest.raises(SystemExit):
+        brb._resolve_extensions_root(tmp_path)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The `install-mundus-staging` job on the merge of #183 (CI run [24599789350](https://github.com/smart-social-contracts/realms/actions/runs/24599789350)) crashed with:

```
✗ Installation failed: No versions found for ext/package_manager
subprocess.CalledProcessError: ... 'realms', 'extension', 'registry-install',
                                    '--extension-id', 'package_manager' ...
```

But the **upstream** `publish-artifacts-staging` job had already silently exited 0 after printing:

```
No frontend-rt/ directories found to build.
No extensions to publish.
```

So nothing was wrong at install-time — the failure was that the registry never received any `ext/*` namespace at all.

## Root cause

`scripts/publish_layered.py` (line 309) and `scripts/build_runtime_bundles.py` (line 195) build the extensions root as:

```python
Path(args.extensions_repo).expanduser().resolve() / "extensions"
```

CI calls them with `--extensions-repo /home/runner/work/realms/realms`, so they look at `<repo>/extensions/`. But the `realms-extensions` submodule has a **nested** layout — extensions actually live at `<repo>/extensions/extensions/<name>/manifest.json`. The outer dir is the submodule root and contains `README.md`, `marketplace/`, `testing/`, `_shared/`, `lint_all_extensions.sh`, etc., none of which have a `manifest.json`. Both scripts iterated zero extension dirs and exited 0.

The 7 extensions that *did* install on staging (`welcome`, `vault`, `erd_explorer`, `llm_chat`, `passport_verification`, `task_monitor`, `notifications`) were leftovers from old `runtime-extension-deploy.yml` runs and remained pinned in file_registry. `package_manager` is the first new extension since the layered architecture landed in #168/#170, so it's the first one to expose the bug — but the bug has been hiding the entire time.

`scripts/ci_install_mundus.py` even has a comment warning about this exact pitfall ("manifests live at `extensions/extensions/<name>/manifest.json`") — but it incorrectly states that "publish_layered.py uses the same inner directory", which is what made the bug invisible.

## What this changes

### `scripts/publish_layered.py` and `scripts/build_runtime_bundles.py`

Add a `_resolve_extensions_root(repo)` helper to each script that:

1. Tries `<repo>/extensions/extensions` first (the realms-monorepo case, this repo).
2. Falls back to `<repo>/extensions` (a standalone `realms-extensions` checkout — preserves the historical local-dev workflow `--extensions-repo ../realms-extensions`).
3. **Fails loud** (`SystemExit`) when neither contains any extension dirs, with a message naming both candidate paths and the likely remedy:
   ```
   ERROR: no extension manifests found under either of:
     /path/to/extensions/extensions  (nested realms+submodule layout)
     /path/to/extensions  (standalone realms-extensions checkout layout)
   Did the realms-extensions submodule fail to initialize? Try:
     git submodule update --init --recursive
   ```
4. Ignores the `_shared` helper dir, the `marketplace/` and `testing/` decoys at the submodule root, and other non-extension siblings — so an empty repo doesn't accidentally get classified as the flat layout.

Also added a fail-loud check for `--only-extensions=<typo>` that matched zero extensions, listing what *was* available.

### `scripts/ci_install_mundus.py`

Fixed the misleading comment block that hid this bug for months.

### `tests/scripts/test_extensions_root_resolution.py`

11 new unit tests covering:
- nested layout
- flat (standalone) layout
- both layouts present (nested wins)
- completely empty repo (raises `SystemExit`)
- only `_shared/` present (raises `SystemExit`)
- only `marketplace/`, `testing/`, `README.md` at the outer level (raises `SystemExit` — does NOT silently classify as flat)
- `--only-extensions=<typo>` lists available alternatives
- `build_runtime_bundles` resolution via `frontend-rt` presence
- `build_runtime_bundles` resolution via `manifest.json` only
- `build_runtime_bundles` flat fallback
- `build_runtime_bundles` empty failure

## Verification

```
$ python3 -m pytest tests/scripts/test_extensions_root_resolution.py -v
============================= 11 passed in 0.03s ==============================
```

Smoke-tested against the real `realms-extensions` submodule pinned in this repo (`c063df6`):

```
$ python3 -c "import sys; sys.path.insert(0, 'scripts'); import publish_layered as pl; \
  print(pl._resolve_extensions_root(__import__('pathlib').Path('.').resolve()))"
/workspace/extensions/extensions

# 21 extensions found, including the previously-missing package_manager:
admin_dashboard, codex_viewer, erd_explorer, hello_world, justice_litigation,
land_registry, llm_chat, market_place, member_dashboard, metrics, notifications,
package_manager, passport_verification, public_dashboard, system_info,
task_monitor, test_bench, vault, voting, welcome, zone_selector
```

## Scope and risk

- **Scope:** path resolution + fail-loud only. No changes to publish/install logic, dfx calls, or CLI surface.
- **Backwards-compat:** the flat layout still works (preserves `--extensions-repo ../realms-extensions` for local dev).
- **Forward-compat:** any future "no extensions found" condition will fail loud instead of silent — much easier to debug.

## After this lands

A re-run of `CI (main)` will publish the missing 21 extensions (including `package_manager`) and the install step will succeed. The `package_manager` extension + the new `admin_dashboard` "Packages" widget will both be installable on Dominion. Tracked separately: wiring `realm_frontend` into the layered staging deploy (out of scope here — only the extension-side changes from #183 will be live until that follow-up lands).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-719985b9-dca6-44ce-b94e-6cd3e961f332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-719985b9-dca6-44ce-b94e-6cd3e961f332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

