### PR TITLE
ci(main): run Phase A (local gating) in parallel with Phase B (staging deploy)

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -1,13 +1,22 @@
 # ci-main.yml — main pipeline.
 #
-# Two phases:
+# Two phases that run in PARALLEL (they target different worlds):
 #   Phase A — local gating: run all four pipeline stages against an
 #             ephemeral local replica inside ONE runner (the local
-#             replica state can't survive a job boundary).
+#             replica state can't survive a job boundary). This is
+#             pure correctness gating — it doesn't touch staging.
 #   Phase B — staging deploy: re-run stages against the real staging
 #             subnet using the four reusable workflows (canisters are
 #             long-lived there so per-stage jobs are fine and give
 #             better observability).
+#
+# Phase B no longer waits on Phase A. The two test different things
+# (correctness vs. real-network deploy); making them sequential added
+# ~10 minutes of pure wall-clock overhead with no signal benefit. If
+# Phase A fails the commit is still bad, but the staging deploy will
+# either succeed (in which case the bug isn't deploy-time) or surface
+# its own failure independently. The `concurrency: ci-main` group
+# below still serializes pushes so two staging deploys never race.
 #
 # To push to mainnet (`ic`), use the manual workflow
 # `layered-deploy-dominion.yml`.
@@ -30,7 +39,7 @@ env:
   DFX_VERSION: "0.31.0"
 
 jobs:
-  # ── Phase A: local gating ──────────────────────────────────────────────────
+  # ── Phase A: local gating (parallel with Phase B) ─────────────────────────
   layered-e2e-local:
     runs-on: ubuntu-latest
     steps:
@@ -65,9 +74,8 @@ jobs:
         if: always()
         run: dfx stop || true
 
-  # ── Phase B: staging deploy (gated on Phase A) ─────────────────────────────
+  # ── Phase B: staging deploy (parallel with Phase A) ────────────────────────
   bootstrap-infra-staging:
-    needs: layered-e2e-local
     uses: ./.github/workflows/_bootstrap-infra.yml
     with:
       network: staging


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Drop the `needs: layered-e2e-local` on `bootstrap-infra-staging` so Phase A and Phase B run in parallel.

## Why

The recent ~34m22s `ci-main` run breaks down as:

| Job | Duration |
| --- | --- |
| `layered-e2e-local` (Phase A) | 10m31s |
| `bootstrap-infra-staging` | 35s |
| `publish-artifacts-staging` | 8m34s |
| `install-mundus-staging` | 13m37s |
| `verify-mundus-staging` (parse + e2e) | ~55s |

Phase A and Phase B test different things — correctness against an ephemeral local replica vs. real staging deploy — and currently waiting for Phase A before kicking off Phase B costs ~10 minutes of pure wall-clock with no signal benefit. If Phase A fails the commit is still bad; the staging deploy will either succeed (in which case the bug isn't deploy-time) or surface its own failure independently.

Expected wall-clock after this change: **~24m** (max of Phase A's 10m and Phase B's ~24m), compared to ~34m today. Phase B itself is unchanged.

The `concurrency: ci-main` group is unchanged so two staging deploys still never race each other.

## Notes on rejected ideas

While analyzing this I considered four other optimizations and dropped them after discussion:

- **Per-realm matrix on `_install-mundus.yml`.** All install messages go through the single `realm_installer` canister, so WASM installs serialize there anyway. Only the canister→canister extension installs would actually parallelize — net win ~4–5 min, not worth the YAML complexity for now.
- **Skip the dfx install in `_bootstrap-infra.yml` when all infra ids are pinned.** The staging descriptor already pins all three, so stage 0 is metadata-only — but the conditional adds enough complexity that ~35s isn't worth it.
- **`cache: pip` / `cache: npm` on the reusable workflows.** Explicitly rejected — caches have been a source of flakes in the past.

## Risk

Low. The change only removes a `needs:` edge in the job graph; both phases already work standalone (e.g. `layered-deploy-dominion.yml` runs Phase B without Phase A).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f8a3429-17e0-4313-a303-f35254533a2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f8a3429-17e0-4313-a303-f35254533a2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

