### PR TITLE
fix(ci): upgrade realm_installer on staging before install-mundus

### DIFF
--- a/.github/workflows/_bootstrap-infra.yml
+++ b/.github/workflows/_bootstrap-infra.yml
@@ -54,7 +54,9 @@ jobs:
           echo "$HOME/.local/share/dfx/bin" >> "$GITHUB_PATH"
 
       - name: Install Python deps
-        run: pip install pyyaml
+        run: |
+          pip install pyyaml
+          pip install -r requirements.txt
 
       - name: Configure dfx identity (non-local only)
         if: ${{ inputs.network != 'local' }}
@@ -82,6 +84,28 @@ jobs:
               --file ${{ inputs.descriptor }} \
               --stages 0 \
               --infra-ids-out infra-ids.json
+
+      # realm_installer is pinned in the staging descriptor (so stage 0
+      # skips it), but we must upgrade it on every push so it has the
+      # latest endpoints (e.g. deploy_realm from #192).  Build with
+      # basilisk and install via dfx canister install --mode upgrade.
+      - name: Upgrade realm_installer (non-local)
+        if: ${{ inputs.network != 'local' }}
+        run: |
+          INSTALLER_ID=$(python3 -c "import json; print(json.load(open('infra-ids.json')).get('realm_installer',''))")
+          if [ -z "$INSTALLER_ID" ]; then
+            echo "::warning::realm_installer not in infra-ids.json — skipping upgrade"
+            exit 0
+          fi
+          echo "Building realm_installer wasm…"
+          CANISTER_CANDID_PATH=src/realm_installer/realm_installer.did \
+            python3 -m basilisk realm_installer src/realm_installer/main.py
+          echo "Upgrading $INSTALLER_ID on ${{ inputs.network }}…"
+          dfx canister install "$INSTALLER_ID" \
+              --wasm .basilisk/realm_installer/realm_installer.wasm \
+              --mode upgrade --yes \
+              --network ${{ inputs.network }}
+          echo "✅ realm_installer upgraded"
 
       - name: Emit infra-ids JSON output
         id: write

--- a/deployments/staging-mundus-layered.yml
+++ b/deployments/staging-mundus-layered.yml
@@ -12,7 +12,13 @@ version: 2
 network: staging
 
 # Pre-existing infrastructure on the staging subnet.
-# These are NOT installed by CI; they're long-lived. CI only verifies them.
+# These are NOT installed by CI; they're long-lived.  CI only verifies
+# them (stage 0 skips `dfx deploy` when a canister_id is pinned).
+#
+# realm_installer is pinned but ALSO upgraded by bootstrap-infra (see
+# the "Upgrade realm_installer" step) so it always matches the code on
+# main.  This is required since ci_install_mundus.py stage 2 now calls
+# deploy_realm, which must exist on the installer canister.
 infrastructure_overrides:
   file_registry:
     canister_id: iebdk-kqaaa-aaaau-agoxq-cai


### PR DESCRIPTION
## Summary

Fixes the staging CI failure introduced by #193 (deploy_realm).

The staging `realm_installer` canister is pinned via `infrastructure_overrides` in the descriptor, so stage 0 skips it. But `ci_install_mundus.py` stage 2 now calls `deploy_realm`, which the old staging installer doesn't have yet.

**Fix**: add a post-stage-0 step in `_bootstrap-infra.yml` that:
1. Installs `requirements.txt` (brings in `ic-basilisk` build tool)
2. Builds the installer wasm with `python -m basilisk`
3. `dfx canister install --mode upgrade` the pinned staging installer

Skipped on `network=local` (local replicas get a fresh install via `dfx deploy` in stage 0).

## Test plan

- [x] YAML validates
- [ ] CI passes (layered-e2e-local runs stage 0-3 on local — this path is unchanged)
- [ ] Staging deploy succeeds (bootstrap upgrades the installer, then stage 2 calls deploy_realm)


Made with [Cursor](https://cursor.com)