### PR TITLE
fix: workaround Basilisk candid_encode trap + add diagnostic endpoints

### DIFF
--- a/scripts/ci_install_mundus.py
+++ b/scripts/ci_install_mundus.py
@@ -611,6 +611,53 @@ def _format_deploy_failures(status: Dict[str, Any]) -> str:
     return "\n".join(lines) if lines else "     (no per-step failures recorded)"
 
 
+def _try_deploy_with_cancel_retry(
+    realm_installer: str,
+    manifest_json: str,
+    name: str,
+    network: str,
+) -> Dict[str, Any]:
+    """Call deploy_realm; if rejected for concurrency, cancel the stale task and retry.
+
+    Returns the parsed kickoff JSON dict on success, raises SystemExit on hard
+    errors.
+    """
+    for attempt in range(2):
+        raw = _unwrap_candid_text(_dfx_call_text(
+            realm_installer, "deploy_realm", manifest_json,
+            network=network, timeout=120,
+        ))
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise SystemExit(
+                f"ERROR: deploy_realm returned non-JSON for {name}: "
+                f"{raw[:300]} ({e})"
+            )
+        if data.get("success"):
+            return data
+
+        conflicting_id = data.get("conflicting_task_id")
+        if conflicting_id and attempt == 0:
+            print(
+                f"   ⚠ {name}: concurrency conflict with {conflicting_id}, "
+                f"cancelling stale deploy…"
+            )
+            cancel_raw = _unwrap_candid_text(_dfx_call_text(
+                realm_installer, "cancel_deploy", conflicting_id,
+                network=network, timeout=60,
+            ))
+            print(f"     cancel result: {cancel_raw[:200]}")
+            time.sleep(2)
+            continue
+
+        raise SystemExit(
+            f"ERROR: deploy_realm rejected for {name}: "
+            f"{data.get('error')}"
+        )
+    raise SystemExit(f"ERROR: deploy_realm still rejected for {name} after cancel")
+
+
 def _kickoff_deploy(
     member: Dict[str, Any],
     *,
@@ -657,22 +704,9 @@ def _kickoff_deploy(
     manifest_json = json.dumps(manifest)
     print(f"     manifest: {manifest_json}")
 
-    kickoff = _unwrap_candid_text(_dfx_call_text(
-        realm_installer, "deploy_realm", manifest_json,
-        network=network, timeout=120,
-    ))
-    try:
-        kickoff_data = json.loads(kickoff)
-    except json.JSONDecodeError as e:
-        raise SystemExit(
-            f"ERROR: deploy_realm returned non-JSON for {name}: "
-            f"{kickoff[:300]} ({e})"
-        )
-    if not kickoff_data.get("success"):
-        raise SystemExit(
-            f"ERROR: deploy_realm rejected for {name}: "
-            f"{kickoff_data.get('error')}"
-        )
+    kickoff_data = _try_deploy_with_cancel_retry(
+        realm_installer, manifest_json, name, network,
+    )
     task_id = kickoff_data["task_id"]
     print(
         f"     queued deploy_realm task_id={task_id} "
@@ -686,13 +720,35 @@ def _kickoff_deploy(
     }
 
 
+def _step_progress_summary(data: Dict[str, Any]) -> str:
+    """Build a compact 'completed/total' summary from a get_deploy_status response."""
+    total = done = failed = 0
+    for bucket in ("extensions", "codices"):
+        for s in (data.get(bucket) or []):
+            total += 1
+            if s.get("status") == "completed":
+                done += 1
+            elif s.get("status") == "failed":
+                failed += 1
+    wasm = data.get("wasm")
+    if wasm:
+        total += 1
+        if wasm.get("status") == "completed":
+            done += 1
+        elif wasm.get("status") == "failed":
+            failed += 1
+    if failed:
+        return f"{done}+{failed}err/{total}"
+    return f"{done}/{total}"
+
+
 def _poll_all_deploys(
     realm_installer: str,
     pending: List[Dict[str, Any]],
     network: str,
     *,
-    timeout: int = 1800,
-    interval: float = 5.0,
+    timeout: int = 3600,
+    interval: float = 10.0,
 ) -> Dict[str, Dict[str, Any]]:
     """Poll every queued deploy in ``pending`` until each reaches terminal.
 
@@ -707,6 +763,7 @@ def _poll_all_deploys(
     remaining = {p["task_id"]: p for p in pending}
     finals: Dict[str, Dict[str, Any]] = {}
     last_status: Dict[str, str] = {}
+    last_progress: Dict[str, str] = {}
 
     while remaining and time.time() < deadline:
         for task_id in list(remaining.keys()):
@@ -727,11 +784,20 @@ def _poll_all_deploys(
                     f"{data.get('error')}"
                 )
             status = data.get("status", "")
-            if status != last_status.get(task_id, ""):
-                name = remaining[task_id]["member"].get("name", "?")
-                print(f"   • {name:<24s} {task_id}: {status}")
+            name = remaining[task_id]["member"].get("name", "?")
+
+            step_summary = _step_progress_summary(data)
+            progress_key = f"{status}|{step_summary}"
+            if progress_key != last_progress.get(task_id, ""):
+                elapsed = int(time.time() - (deadline - timeout))
+                print(
+                    f"   • {name:<24s} {task_id}: {status}"
+                    f"  [{step_summary}]  ({elapsed}s)"
+                )
+                last_progress[task_id] = progress_key
                 last_status[task_id] = status
-            if status in ("completed", "partial", "failed"):
+
+            if status in ("completed", "partial", "failed", "cancelled"):
                 finals[task_id] = data
                 del remaining[task_id]
         if remaining:
@@ -739,9 +805,14 @@ def _poll_all_deploys(
 
     if remaining:
         names = ", ".join(p["member"].get("name", "?") for p in remaining.values())
+        elapsed = int(time.time() - (deadline - timeout))
+        for task_id, p in remaining.items():
+            n = p["member"].get("name", "?")
+            prog = last_progress.get(task_id, "?")
+            print(f"   ⚠ {n:<24s} {task_id}: last progress = {prog}")
         raise SystemExit(
-            f"ERROR: deploys did not reach terminal status within {timeout}s: "
-            f"{names}"
+            f"ERROR: deploys did not reach terminal status within {timeout}s "
+            f"({elapsed}s elapsed): {names}"
         )
     return finals
 
@@ -787,12 +858,14 @@ def stage2_install(descriptor: Dict[str, Any], infra_ids: Dict[str, str]) -> Non
 
     # PHASE 2: poll every in-flight deploy in a single shared loop. The
     # target realms are independent canisters → their installs run
-    # concurrently on different IC subnet replicas. With ~3 realms this
-    # collapses ~13m of serial work into ~5m wall-clock.
-    print(f"\n   ⏳ awaiting {len(pending)} deploy(s) (timeout 1800s)…")
+    # concurrently on different IC subnet replicas.  Each extension step
+    # involves inter-canister calls (~3-10s each on real subnets), and
+    # with 20+ extensions per realm the total can exceed 30 minutes.
+    deploy_timeout = 3600
+    print(f"\n   ⏳ awaiting {len(pending)} deploy(s) (timeout {deploy_timeout}s)…")
     finals = _poll_all_deploys(
         realm_installer, pending, network,
-        timeout=1800, interval=5.0,
+        timeout=deploy_timeout, interval=10.0,
     )
 
     # PHASE 3: validate per-realm outcomes + register with registry.

--- a/scripts/ci_install_mundus.py
+++ b/scripts/ci_install_mundus.py
@@ -628,7 +628,7 @@ def _try_deploy_with_cancel_retry(
             network=network, timeout=120,
         ))
         try:
-            data = json.loads(raw)
+            data = json.loads(raw, strict=False)
         except json.JSONDecodeError as e:
             raise SystemExit(
                 f"ERROR: deploy_realm returned non-JSON for {name}: "
@@ -773,7 +773,7 @@ def _poll_all_deploys(
             )
             body = _unwrap_candid_text(out)
             try:
-                data = json.loads(body)
+                data = json.loads(body, strict=False)
             except json.JSONDecodeError:
                 print(f"   ⚠️  unparseable get_deploy_status({task_id}): "
                       f"{body[:200]}")

--- a/src/realm_installer/main.py
+++ b/src/realm_installer/main.py
@@ -104,6 +104,36 @@ from ic_python_db import (
     TimestampedMixin,
 )
 
+# ---------------------------------------------------------------------------
+# Monkey-patch: fix Basilisk's _ServiceCall to avoid trap on string encoding.
+#
+# The built-in _ServiceCall.__init__ calls _to_candid_text (which doesn't
+# escape inner quotes in strings) followed by _basilisk_ic.candid_encode()
+# (which calls ic_cdk::trap instead of raising a Python exception on parse
+# errors).  This combination is fatal for inter-canister calls whose
+# arguments contain JSON strings like '{"key":"val"}'.
+#
+# We replace __init__ to skip the broken text-encoding path entirely.
+# The Rust-side typed encoding (encode_service_call_args Priority 1) handles
+# the actual serialisation when _python_call_args + _candid_arg_type are set.
+# ---------------------------------------------------------------------------
+try:
+    import basilisk as _bsk
+    _SC = _bsk._ServiceCall
+
+    def _safe_sc_init(self, canister_principal, method_name, call_args=None,
+                      payment=0, arg_type=None):
+        self._python_call_args = call_args if call_args else ()
+        self._candid_arg_type = arg_type
+        self._raw_args = b'DIDL\x00\x00'
+        self.canister_principal = canister_principal
+        self.method_name = method_name
+        self.payment = payment
+
+    _SC.__init__ = _safe_sc_init
+except Exception:
+    pass
+
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -138,7 +168,10 @@ _NEXT_STEP_DELAY_S = 0
 _db_storage = StableBTreeMap[str, str](
     memory_id=1, max_key_size=200, max_value_size=10000
 )
-Database.init(db_storage=_db_storage, audit_enabled=False)
+try:
+    Database.init(db_storage=_db_storage, audit_enabled=False)
+except RuntimeError:
+    pass  # already initialized (canister upgrade re-runs module code)
 
 
 # ---------------------------------------------------------------------------
@@ -164,6 +197,11 @@ class FileRegistryService(Service):
 # ---------------------------------------------------------------------------
 
 class RealmTargetService(Service):
+    _arg_types = {
+        "install_extension_from_registry": "text",
+        "install_codex_from_registry": "text",
+    }
+
     @service_update
     def install_extension_from_registry(self, args: text) -> text: ...
 
@@ -835,18 +873,17 @@ def _execute_step(task: DeployTask, step: DeployStep):
 
 
 def _schedule_step_runner(task_id: str, delay_s: int = 0) -> None:
-    """Set an IC timer that, on fire, advances ``task_id`` by one step.
+    """Set an IC timer that runs ALL remaining steps for ``task_id``.
 
-    Each fire is its own update message → fresh ~40B instruction
-    budget → no risk of hitting the per-message limit no matter how
-    large the manifest.
+    Uses a single timer callback with a loop: each ``yield`` within a
+    step gives the IC a fresh instruction budget, so there's no risk
+    of hitting the per-message limit.  This avoids the timer-chain
+    pattern (timer → step → schedule next timer) which breaks in
+    Basilisk when a generator callback schedules another generator
+    callback.
     """
     def _cb():
-        # CRITICAL: any uncaught exception in a timer callback traps the
-        # runtime and rolls back state.  Wrap everything.
         try:
-            # Re-load entities inside the callback so we see the latest
-            # writes from the previous step's update message.
             list(DeployStep.instances())
             list(DeployTask.instances())
             task = DeployTask[task_id]
@@ -864,16 +901,23 @@ def _schedule_step_runner(task_id: str, delay_s: int = 0) -> None:
                 task.status = "running"
                 task.started_at = _now_s()
 
-            step = _next_pending_step(task)
-            if step is None:
-                _finalize_task(task)
-                return
+            while True:
+                step = _next_pending_step(task)
+                if step is None:
+                    _finalize_task(task)
+                    return
 
-            yield from _execute_step(task, step)
+                # Check for cancellation between steps.
+                list(DeployTask.instances())
+                task = DeployTask[task_id]
+                if not task or (task.status or "") in _TERMINAL_TASK_STATUSES:
+                    ic.print(
+                        f"[realm_installer] deploy {task_id}: "
+                        f"cancelled mid-run, stopping"
+                    )
+                    return
 
-            # Keep going.  If the just-finished step was the last pending
-            # step, the next callback will finalize the task.
-            _schedule_step_runner(task_id, _NEXT_STEP_DELAY_S)
+                yield from _execute_step(task, step)
         except Exception as e:
             ic.print(
                 f"[realm_installer] timer callback fatal error for "
@@ -1163,6 +1207,125 @@ def _on_init() -> None:
 def _on_post_upgrade() -> None:
     ic.print("[realm_installer] post_upgrade — resuming in-flight deploys")
     _resume_in_flight_deploys()
+
+
+# ---------------------------------------------------------------------------
+# Shell (for basilisk exec / basilisk shell)
+# ---------------------------------------------------------------------------
+
+_shell_namespaces: dict = {}
+
+@update
+def execute_code_shell(code: str) -> str:
+    import io as _io
+    import sys as _sys
+    import traceback as _tb
+
+    caller = str(ic.caller())
+    if caller not in _shell_namespaces:
+        _shell_namespaces[caller] = {
+            "__builtins__": __builtins__,
+            "ic": ic,
+            "json": json,
+            "DeployTask": DeployTask,
+            "DeployStep": DeployStep,
+            "Database": Database,
+            "_db_storage": _db_storage,
+        }
+    ns = _shell_namespaces[caller]
+    out, err = _io.StringIO(), _io.StringIO()
+    _sys.stdout, _sys.stderr = out, err
+    try:
+        exec(code, ns, ns)
+    except Exception:
+        _tb.print_exc()
+    _sys.stdout, _sys.stderr = _sys.__stdout__, _sys.__stderr__
+    return out.getvalue() + err.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic endpoint — manual resume for stuck deploys
+# ---------------------------------------------------------------------------
+
+@update
+def debug_run_one_step(args: text) -> Async[text]:
+    """Directly execute the next pending step for a task, bypassing timers.
+
+    This is a diagnostic endpoint to isolate timer-vs-generator issues.
+    """
+    try:
+        task_id = args.strip()
+        list(DeployStep.instances())
+        list(DeployTask.instances())
+        task = DeployTask[task_id]
+        if not task:
+            return _err(f"task {task_id} not found")
+
+        step = _next_pending_step(task)
+        if step is None:
+            return _ok({"message": "no pending steps", "task_status": task.status})
+
+        if (task.status or "queued") == "queued":
+            task.status = "running"
+            task.started_at = _now_s()
+
+        ic.print(
+            f"[debug_run_one_step] executing step {step.idx} "
+            f"({step.kind} {step.label}) for {task_id}"
+        )
+        yield from _execute_step(task, step)
+
+        remaining = len([s for s in task.steps if s.status == "pending"])
+        return _ok({
+            "step_idx": int(step.idx),
+            "step_kind": step.kind,
+            "step_label": step.label,
+            "step_status": step.status,
+            "step_error": step.error or "",
+            "remaining_pending": remaining,
+        })
+    except Exception as e:
+        ic.print(f"[debug_run_one_step] error: {e}")
+        return _err(f"{type(e).__name__}: {e}")
+
+
+@update
+def debug_resume_deploys(args: text) -> text:
+    """Manually resume any stuck (running/queued) deploys.
+
+    This is a diagnostic/recovery endpoint.  It does the same thing as
+    post_upgrade's _resume_in_flight_deploys but can be called without
+    upgrading the canister.  Returns a summary of what was resumed.
+    """
+    try:
+        list(DeployStep.instances())
+        resumed = []
+        for t in DeployTask.instances():
+            try:
+                if (t.status or "queued") in _ACTIVE_TASK_STATUSES:
+                    pending_steps = [s for s in t.steps if s.status == "pending"]
+                    running_steps = [s for s in t.steps if s.status == "running"]
+                    for s in t.steps:
+                        if s.status == "running":
+                            s.status = "pending"
+                            s.started_at = 0
+                    t.status = "queued"
+                    _schedule_step_runner(t.name, 0)
+                    resumed.append({
+                        "task_id": t.name,
+                        "target": t.target_canister_id,
+                        "pending_steps": len(pending_steps),
+                        "reset_running_steps": len(running_steps),
+                    })
+                    ic.print(
+                        f"[realm_installer] debug_resume: restarting {t.name} "
+                        f"({len(pending_steps)} pending, {len(running_steps)} running→pending)"
+                    )
+            except Exception as e:
+                resumed.append({"task_id": str(t), "error": str(e)})
+        return json.dumps({"success": True, "resumed": resumed})
+    except Exception as e:
+        return json.dumps({"success": False, "error": str(e)})
 
 
 # ---------------------------------------------------------------------------

--- a/src/realm_installer/main.py
+++ b/src/realm_installer/main.py
@@ -113,22 +113,29 @@ from ic_python_db import (
 # errors).  This combination is fatal for inter-canister calls whose
 # arguments contain JSON strings like '{"key":"val"}'.
 #
-# We replace __init__ to skip the broken text-encoding path entirely.
-# The Rust-side typed encoding (encode_service_call_args Priority 1) handles
-# the actual serialisation when _python_call_args + _candid_arg_type are set.
+# When the Service class provides _arg_types for a method, we skip the
+# broken text-encoding path and let the Rust-side typed encoding handle
+# serialisation via _python_call_args + _candid_arg_type.  For methods
+# WITHOUT _arg_types (e.g. FileRegistryService), we fall back to the
+# original __init__ which works fine for simple string arguments.
 # ---------------------------------------------------------------------------
 try:
     import basilisk as _bsk
     _SC = _bsk._ServiceCall
+    _original_sc_init = _SC.__init__
 
     def _safe_sc_init(self, canister_principal, method_name, call_args=None,
                       payment=0, arg_type=None):
-        self._python_call_args = call_args if call_args else ()
-        self._candid_arg_type = arg_type
-        self._raw_args = b'DIDL\x00\x00'
-        self.canister_principal = canister_principal
-        self.method_name = method_name
-        self.payment = payment
+        if arg_type is not None:
+            self._python_call_args = call_args if call_args else ()
+            self._candid_arg_type = arg_type
+            self._raw_args = b'DIDL\x00\x00'
+            self.canister_principal = canister_principal
+            self.method_name = method_name
+            self.payment = payment
+        else:
+            _original_sc_init(self, canister_principal, method_name,
+                              call_args, payment, arg_type)
 
     _SC.__init__ = _safe_sc_init
 except Exception:


### PR DESCRIPTION
## Summary
- Fixes deploy_realm extension steps silently failing due to Basilisk `_to_candid_text` / `candid_encode` bugs
- Monkey-patches `_ServiceCall.__init__` to skip broken text-encoding path and use typed encoding
- Refactors timer chain to single-timer-with-loop pattern for robustness
- Adds `debug_run_one_step`, `debug_resume_deploys`, `execute_code_shell` diagnostic endpoints

## Context
The `deploy_realm` WASM step would complete, but all extension steps would remain `pending` forever. Root cause: Basilisk's `_to_candid_text` doesn't escape quotes in JSON strings, and `candid_encode` traps (Rust-level abort) instead of raising a Python exception. The underlying Basilisk fix is in [basilisk#43](https://github.com/smart-social-contracts/basilisk/pull/43); this PR adds application-level workarounds so realm_installer works with both fixed and unfixed Basilisk versions.

## Test plan
- [x] Verified extension steps complete on staging via `debug_run_one_step`
- [x] Verified all 3 realm deploys reached `completed` status on staging
- [ ] CI end-to-end test passes

Made with [Cursor](https://cursor.com)