### PR TITLE
chore: bump ic-basilisk to 0.11.26, remove monkey-patch

### DIFF
--- a/cli/realms/cli/requirements.txt
+++ b/cli/realms/cli/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --allow-unsafe --output-file=cli/realms/cli/requirements.txt --strip-extras cli/realms/cli/requirements.in
 #
-ic-basilisk==0.11.25
+ic-basilisk==0.11.26
     # via -r cli/realms/cli/requirements.in
 ic-python-db==0.7.9
     # via -r cli/realms/cli/requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --allow-unsafe --output-file=requirements.txt --strip-extras requirements.in
 #
-ic-basilisk==0.11.25
+ic-basilisk==0.11.26
     # via ic-basilisk-toolkit
 ic-basilisk-toolkit==0.1.5
     # via -r requirements.in

--- a/src/marketplace_backend/requirements.txt
+++ b/src/marketplace_backend/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --allow-unsafe --output-file=src/marketplace_backend/requirements.txt --strip-extras src/marketplace_backend/requirements.in
 #
-ic-basilisk==0.11.25
+ic-basilisk==0.11.26
     # via
     #   -r src/marketplace_backend/requirements.in
     #   ic-basilisk-toolkit

--- a/src/realm_installer/main.py
+++ b/src/realm_installer/main.py
@@ -105,44 +105,6 @@ from ic_python_db import (
 )
 
 # ---------------------------------------------------------------------------
-# Monkey-patch: fix Basilisk's _ServiceCall to avoid trap on string encoding.
-#
-# The built-in _ServiceCall.__init__ calls _to_candid_text (which doesn't
-# escape inner quotes in strings) followed by _basilisk_ic.candid_encode()
-# (which calls ic_cdk::trap instead of raising a Python exception on parse
-# errors).  This combination is fatal for inter-canister calls whose
-# arguments contain JSON strings like '{"key":"val"}'.
-#
-# When the Service class provides _arg_types for a method, we skip the
-# broken text-encoding path and let the Rust-side typed encoding handle
-# serialisation via _python_call_args + _candid_arg_type.  For methods
-# WITHOUT _arg_types (e.g. FileRegistryService), we fall back to the
-# original __init__ which works fine for simple string arguments.
-# ---------------------------------------------------------------------------
-try:
-    import basilisk as _bsk
-    _SC = _bsk._ServiceCall
-    _original_sc_init = _SC.__init__
-
-    def _safe_sc_init(self, canister_principal, method_name, call_args=None,
-                      payment=0, arg_type=None):
-        if arg_type is not None:
-            self._python_call_args = call_args if call_args else ()
-            self._candid_arg_type = arg_type
-            self._raw_args = b'DIDL\x00\x00'
-            self.canister_principal = canister_principal
-            self.method_name = method_name
-            self.payment = payment
-        else:
-            _original_sc_init(self, canister_principal, method_name,
-                              call_args, payment, arg_type)
-
-    _SC.__init__ = _safe_sc_init
-except Exception:
-    pass
-
-
-# ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
 

--- a/src/realm_installer/requirements.txt
+++ b/src/realm_installer/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --allow-unsafe --output-file=src/realm_installer/requirements.txt --strip-extras src/realm_installer/requirements.in
 #
-ic-basilisk==0.11.25
+ic-basilisk==0.11.26
     # via
     #   -r src/realm_installer/requirements.in
     #   ic-basilisk-toolkit

--- a/src/realm_registry_backend/requirements.txt
+++ b/src/realm_registry_backend/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --allow-unsafe --output-file=src/realm_registry_backend/requirements.txt --strip-extras src/realm_registry_backend/requirements.in
 #
-ic-basilisk==0.11.25
+ic-basilisk==0.11.26
     # via -r src/realm_registry_backend/requirements.in
 ic-python-db==0.7.9
     # via -r src/realm_registry_backend/requirements.in


### PR DESCRIPTION
## Summary
- Bumps `ic-basilisk` from 0.11.25 to 0.11.26 across all requirements files
- Removes the `_ServiceCall.__init__` monkey-patch from `realm_installer/main.py`

v0.11.26 fixes two bugs in the Basilisk template:
1. `_to_candid_text` now properly escapes quotes and backslashes in string arguments
2. `ic.candid_encode()` raises a catchable Python `ValueError` instead of calling `ic_cdk::trap()`

With these fixes baked into the template, the monkey-patch workaround is no longer needed.

## Test plan
- [ ] CI lint + unit pass
- [ ] CI layered-e2e passes (full local deploy with WASM + extensions)

Made with [Cursor](https://cursor.com)