### PR TITLE
fix(ci): handle missing .did file and Node.js in registry frontend deploy

### DIFF
--- a/.github/workflows/_install-mundus.yml
+++ b/.github/workflows/_install-mundus.yml
@@ -26,6 +26,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.10"
+  NODE_VERSION: "20"
   DFX_VERSION: "0.31.0"
 
 jobs:
@@ -39,6 +40,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
 
       - name: Install dfx ${{ env.DFX_VERSION }}
         run: |

--- a/scripts/ci_install_mundus.py
+++ b/scripts/ci_install_mundus.py
@@ -993,18 +993,42 @@ def _deploy_registry_frontend(descriptor: Dict[str, Any]) -> None:
               f"{network} — skipping frontend deploy")
         return
 
+    if not shutil.which("npm"):
+        print("   ⚠ npm not found — skipping realm_registry_frontend deploy "
+              "(install Node.js to enable)")
+        return
+
     print("\n   📦 building & deploying realm_registry_frontend …")
 
-    # Generate TS declarations from the backend .did file.  The backend
-    # is declared `remote` on staging/demo so dfx reads the local .did
-    # without contacting the canister.
-    _run(["dfx", "generate", "realm_registry_backend"],
-         cwd=REPO_ROOT, check=False)
+    # The frontend's prebuild script runs `dfx generate realm_registry_backend`
+    # which needs the .did file.  In single-job workflows (fast-deploy) stage 1
+    # already built the backend and the .did exists.  In multi-job pipelines
+    # (ci-main) stage 1 ran on a different runner, so we may need to generate
+    # the .did ourselves via a basilisk build.
+    did_path = REPO_ROOT / "src" / "realm_registry_backend" / "realm_registry_backend.did"
+    if not did_path.exists():
+        print("   • .did file missing — building realm_registry_backend to generate it …")
+        env = os.environ.copy()
+        env["CANISTER_CANDID_PATH"] = str(did_path)
+        _run([
+            sys.executable, "-m", "basilisk",
+            "realm_registry_backend",
+            str(REPO_ROOT / "src" / "realm_registry_backend" / "main.py"),
+        ], cwd=REPO_ROOT, env=env, check=False)
 
-    # Build the SvelteKit frontend (npm deps already installed by the
-    # workflow's `npm ci` step).
-    _run(["npm", "run", "build", "--workspace=realm_registry_frontend"],
-         cwd=REPO_ROOT)
+    if did_path.exists():
+        _run(["dfx", "generate", "realm_registry_backend"],
+             cwd=REPO_ROOT, check=False)
+    else:
+        print("   ⚠ could not generate .did file — frontend build may fail")
+
+    # Install npm deps if not already present (idempotent).
+    _run(["npm", "ci", "--ignore-scripts"], cwd=REPO_ROOT, check=False)
+
+    # Build the SvelteKit frontend directly via vite, bypassing the
+    # prebuild hook (we already ran dfx generate above).
+    _run(["npx", "vite", "build"],
+         cwd=REPO_ROOT / "src" / "realm_registry_frontend")
 
     # Upload the built assets to the existing canister.
     _dfx("deploy", "realm_registry_frontend", "--yes", network=network)


### PR DESCRIPTION
## Summary

Follow-up to #199 — the registry frontend deploy step failed in `ci-main`'s multi-job pipeline because:

1. **Missing `.did` file**: The candid file is generated by basilisk during stage 1, which runs on a different runner than stage 2 (install-mundus). The script now auto-detects the missing `.did` and builds it via basilisk on-demand.
2. **Missing Node.js**: `_install-mundus.yml` didn't install Node.js. Added `setup-node` to the workflow.
3. **Prebuild hook conflict**: The `npm run build` workspace command re-ran `dfx generate` via the prebuild hook (which fails without the `.did`). Now runs `npx vite build` directly after manually generating declarations.

Also gracefully skips the deploy if npm is not available (defensive, won't block backend-only deploys).

Closes #198

## Test plan

- [ ] PR CI passes (lint + unit + layered-e2e-local)
- [ ] After merge, ci-main pipeline completes successfully (including install-mundus-staging with registry frontend deploy)
- [ ] Registry frontend shows marketplace button on both staging and demo after next Deploy

Made with [Cursor](https://cursor.com)