### PR TITLE
feat: add platform_dashboard_frontend canister

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -234,6 +234,13 @@
       "type": "assets",
       "workspace": "marketplace_frontend",
       "dependencies": ["marketplace_backend"]
+    },
+    "platform_dashboard_frontend": {
+      "source": [
+        "src/platform_dashboard_frontend/dist"
+      ],
+      "type": "assets",
+      "workspace": "platform_dashboard_frontend"
     }
   },
   "defaults": { 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
         "src/realm_frontend",
         "src/realm_registry_frontend",
         "src/file_registry_frontend",
-        "src/marketplace_frontend"
+        "src/marketplace_frontend",
+        "src/realm_installer_frontend",
+        "src/platform_dashboard_frontend"
       ],
       "dependencies": {
         "@dfinity/agent": "^3.4.3",
@@ -5377,6 +5379,10 @@
         "node": ">= 6"
       }
     },
+    "node_modules/platform_dashboard_frontend": {
+      "resolved": "src/platform_dashboard_frontend",
+      "link": true
+    },
     "node_modules/playwright": {
       "version": "1.55.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
@@ -5857,6 +5863,10 @@
     },
     "node_modules/realm_frontend": {
       "resolved": "src/realm_frontend",
+      "link": true
+    },
+    "node_modules/realm_installer_frontend": {
+      "resolved": "src/realm_installer_frontend",
       "link": true
     },
     "node_modules/realm_registry_frontend": {
@@ -8294,6 +8304,120 @@
         }
       }
     },
+    "src/platform_dashboard_frontend": {
+      "version": "0.0.0",
+      "dependencies": {
+        "@dfinity/agent": "^3.2.4",
+        "@dfinity/auth-client": "^3.2.4",
+        "@dfinity/candid": "^3.2.4",
+        "@dfinity/identity": "^3.2.4",
+        "@dfinity/principal": "^3.2.4"
+      },
+      "devDependencies": {
+        "@sveltejs/adapter-static": "^3.0.4",
+        "@sveltejs/kit": "^2.5.26",
+        "@sveltejs/vite-plugin-svelte": "^3.1.2",
+        "dotenv": "^16.3.1",
+        "svelte": "^4.2.19",
+        "svelte-check": "^4.0.1",
+        "typescript": "^5.6.2",
+        "vite": "^5.4.3",
+        "vite-plugin-environment": "^1.1.3",
+        "vitest": "^2.0.0"
+      }
+    },
+    "src/platform_dashboard_frontend/node_modules/@sveltejs/vite-plugin-svelte": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-3.1.2.tgz",
+      "integrity": "sha512-Txsm1tJvtiYeLUVRNqxZGKR/mI+CzuIQuc2gn+YCs9rMTowpNZ2Nqt53JdL8KF9bLhAf2ruR/dr9eZCwdTriRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sveltejs/vite-plugin-svelte-inspector": "^2.1.0",
+        "debug": "^4.3.4",
+        "deepmerge": "^4.3.1",
+        "kleur": "^4.1.5",
+        "magic-string": "^0.30.10",
+        "svelte-hmr": "^0.16.0",
+        "vitefu": "^0.2.5"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20"
+      },
+      "peerDependencies": {
+        "svelte": "^4.0.0 || ^5.0.0-next.0",
+        "vite": "^5.0.0"
+      }
+    },
+    "src/platform_dashboard_frontend/node_modules/@sveltejs/vite-plugin-svelte-inspector": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-2.1.0.tgz",
+      "integrity": "sha512-9QX28IymvBlSCqsCll5t0kQVxipsfhFFL+L2t3nTWfXnddYwxBuAEtTtlaVQpRz9c37BhJjltSeY4AJSC03SSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20"
+      },
+      "peerDependencies": {
+        "@sveltejs/vite-plugin-svelte": "^3.0.0",
+        "svelte": "^4.0.0 || ^5.0.0-next.0",
+        "vite": "^5.0.0"
+      }
+    },
+    "src/platform_dashboard_frontend/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "src/platform_dashboard_frontend/node_modules/svelte": {
+      "version": "4.2.20",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.20.tgz",
+      "integrity": "sha512-eeEgGc2DtiUil5ANdtd8vPwt9AgaMdnuUFnPft9F5oMvU/FHu5IHFic+p1dR/UOB7XU2mX2yHW+NcTch4DCh5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.15",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/estree": "^1.0.1",
+        "acorn": "^8.9.0",
+        "aria-query": "^5.3.0",
+        "axobject-query": "^4.0.0",
+        "code-red": "^1.0.3",
+        "css-tree": "^2.3.1",
+        "estree-walker": "^3.0.3",
+        "is-reference": "^3.0.1",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.4",
+        "periscopic": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "src/platform_dashboard_frontend/node_modules/vitefu": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-0.2.5.tgz",
+      "integrity": "sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
     "src/realm_frontend": {
       "version": "0.0.0",
       "dependencies": {
@@ -8353,6 +8477,9 @@
       "peerDependencies": {
         "svelte": "^5.19.0"
       }
+    },
+    "src/realm_installer_frontend": {
+      "version": "0.1.0"
     },
     "src/realm_registry_frontend": {
       "version": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "src/realm_registry_frontend",
     "src/file_registry_frontend",
     "src/marketplace_frontend",
-    "src/realm_installer_frontend"
+    "src/realm_installer_frontend",
+    "src/platform_dashboard_frontend"
   ],
   "dependencies": {
     "@dfinity/agent": "^3.4.3",

--- a/scripts/ci_install_mundus.py
+++ b/scripts/ci_install_mundus.py
@@ -1043,6 +1043,64 @@ def _deploy_registry_frontend(descriptor: Dict[str, Any]) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Deploy platform_dashboard_frontend (asset canister, outside mundus pipeline)
+# ---------------------------------------------------------------------------
+
+
+def _deploy_dashboard_frontend(descriptor: Dict[str, Any]) -> None:
+    """Build and deploy the platform_dashboard_frontend asset canister.
+
+    The dashboard is an admin-facing SvelteKit frontend that provides a
+    unified directory of all platform canisters, links to each
+    canister's frontend or Candid UI, and an installer deployment
+    dashboard.  It is not part of the mundus realm pipeline — it is
+    deployed as a standalone asset canister alongside the registry
+    frontend.
+    """
+    network = descriptor["network"]
+    frontend_id = _canister_id("platform_dashboard_frontend", network)
+    if not frontend_id:
+        print("   ⚠ platform_dashboard_frontend has no canister id on "
+              f"{network} — skipping dashboard deploy")
+        return
+
+    if not shutil.which("npm"):
+        print("   ⚠ npm not found — skipping platform_dashboard_frontend "
+              "deploy (install Node.js to enable)")
+        return
+
+    print("\n   📦 building & deploying platform_dashboard_frontend …")
+
+    # Ensure all .did files exist for dfx generate (prebuild generates
+    # declarations for registry, installer, marketplace, file_registry,
+    # realm_backend).  Only generate what is missing.
+    for canister_name in [
+        "realm_registry_backend", "realm_installer",
+        "marketplace_backend", "file_registry", "realm_backend",
+    ]:
+        did_stem = canister_name
+        did_path = REPO_ROOT / "src" / canister_name / f"{canister_name}.did"
+        if did_path.exists():
+            _run(["dfx", "generate", canister_name],
+                 cwd=REPO_ROOT, check=False)
+
+    node_modules = REPO_ROOT / "node_modules"
+    if not node_modules.exists():
+        _run(["npm", "install", "--legacy-peer-deps"],
+             cwd=REPO_ROOT, check=False)
+
+    _run(["npm", "run", "build",
+          "--workspace=platform_dashboard_frontend"],
+         cwd=REPO_ROOT)
+
+    _dfx("deploy", "platform_dashboard_frontend", "--yes",
+         network=network)
+
+    print(f"   ✅ platform_dashboard_frontend deployed → "
+          f"https://{frontend_id}.icp0.io/")
+
+
+# ---------------------------------------------------------------------------
 # Stage 3 — verify (seed data, smoke)
 # ---------------------------------------------------------------------------
 
@@ -1182,6 +1240,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     if 2 in stages:
         stage2_install(descriptor, infra_ids)
         _deploy_registry_frontend(descriptor)
+        _deploy_dashboard_frontend(descriptor)
     if 3 in stages:
         stage3_verify(descriptor)
 

--- a/src/platform_dashboard_frontend/package.json
+++ b/src/platform_dashboard_frontend/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "platform_dashboard_frontend",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "vite --port 3003",
+    "prebuild": "dfx generate realm_registry_backend && dfx generate realm_installer && dfx generate marketplace_backend && dfx generate file_registry && dfx generate realm_backend",
+    "build": "vite build",
+    "test": "vitest run",
+    "format": "prettier --write \"src/**/*.{json,js,jsx,ts,tsx,css,svelte}\""
+  },
+  "dependencies": {
+    "@dfinity/agent": "^3.2.4",
+    "@dfinity/auth-client": "^3.2.4",
+    "@dfinity/candid": "^3.2.4",
+    "@dfinity/identity": "^3.2.4",
+    "@dfinity/principal": "^3.2.4"
+  },
+  "devDependencies": {
+    "@sveltejs/adapter-static": "^3.0.4",
+    "@sveltejs/kit": "^2.5.26",
+    "@sveltejs/vite-plugin-svelte": "^3.1.2",
+    "dotenv": "^16.3.1",
+    "svelte": "^4.2.19",
+    "svelte-check": "^4.0.1",
+    "typescript": "^5.6.2",
+    "vite": "^5.4.3",
+    "vite-plugin-environment": "^1.1.3",
+    "vitest": "^2.0.0"
+  }
+}

--- a/src/platform_dashboard_frontend/src/app.css
+++ b/src/platform_dashboard_frontend/src/app.css
@@ -1,0 +1,207 @@
+:root {
+  --bg: #f8f9fb;
+  --surface: #ffffff;
+  --surface-2: #f1f3f5;
+  --surface-3: #e9ecef;
+  --border: #dee2e6;
+  --border-strong: #ced4da;
+  --text: #1a1a2e;
+  --text-muted: #495057;
+  --text-faint: #868e96;
+  --primary: #2563eb;
+  --primary-hover: #1d4ed8;
+  --primary-light: #dbeafe;
+  --accent: #7c3aed;
+  --success: #16a34a;
+  --success-bg: #dcfce7;
+  --warning: #d97706;
+  --warning-bg: #fef3c7;
+  --danger: #dc2626;
+  --danger-bg: #fee2e2;
+  --info: #0891b2;
+  --info-bg: #cffafe;
+  --sidebar-width: 240px;
+  --topbar-height: 56px;
+  color-scheme: light dark;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0f1117;
+    --surface: #1a1b26;
+    --surface-2: #24253a;
+    --surface-3: #2f3047;
+    --border: #2f3047;
+    --border-strong: #3b3d57;
+    --text: #e1e2e8;
+    --text-muted: #a0a3b1;
+    --text-faint: #6b6f80;
+    --primary: #3b82f6;
+    --primary-hover: #60a5fa;
+    --primary-light: #1e3a5f;
+    --success: #22c55e;
+    --success-bg: #14291e;
+    --warning: #eab308;
+    --warning-bg: #2a2411;
+    --danger: #ef4444;
+    --danger-bg: #2d1515;
+    --info: #06b6d4;
+    --info-bg: #0c2a30;
+  }
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: inherit; }
+button { font: inherit; cursor: pointer; }
+
+code, pre {
+  font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2em 0.6em;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+}
+.badge-success { background: var(--success-bg); color: var(--success); }
+.badge-warning { background: var(--warning-bg); color: var(--warning); }
+.badge-danger  { background: var(--danger-bg);  color: var(--danger); }
+.badge-info    { background: var(--info-bg);    color: var(--info); }
+.badge-neutral { background: var(--surface-2);  color: var(--text-muted); }
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+  transition: box-shadow 0.15s ease;
+}
+.card:hover {
+  box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-muted);
+  padding: 0.45rem 0.85rem;
+  border-radius: 0.5rem;
+  font-size: 0.85rem;
+  transition: all 0.15s ease;
+  text-decoration: none;
+}
+.btn:hover { background: var(--surface-2); color: var(--text); }
+.btn-primary { background: var(--primary); border-color: var(--primary); color: #fff; }
+.btn-primary:hover { background: var(--primary-hover); border-color: var(--primary-hover); color: #fff; }
+.btn-sm { padding: 0.3rem 0.6rem; font-size: 0.8rem; }
+
+.link-external {
+  color: var(--primary);
+  text-decoration: none;
+  font-size: 0.8rem;
+}
+.link-external:hover { text-decoration: underline; }
+
+.spinner {
+  display: inline-block;
+  width: 1.25em;
+  height: 1.25em;
+  border: 2px solid var(--border);
+  border-top-color: var(--primary);
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.empty-state {
+  text-align: center;
+  padding: 3rem 1rem;
+  color: var(--text-faint);
+}
+
+.page-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 0 0 0.25rem;
+}
+.page-subtitle {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  margin: 0 0 1.5rem;
+}
+
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+.stat-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 1rem 1.25rem;
+}
+.stat-value {
+  font-size: 1.75rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+.stat-label {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-top: 0.15rem;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+th, td {
+  text-align: left;
+  padding: 0.65rem 0.85rem;
+  border-bottom: 1px solid var(--border);
+}
+th {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-faint);
+  background: var(--surface-2);
+}
+td { font-size: 0.875rem; }
+tr:hover td { background: var(--surface-2); }
+
+input[type="search"],
+input[type="text"] {
+  width: 100%;
+  padding: 0.55rem 0.85rem;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background: var(--surface);
+  color: var(--text);
+  font-size: 0.875rem;
+  outline: none;
+  transition: border-color 0.15s;
+}
+input:focus { border-color: var(--primary); }

--- a/src/platform_dashboard_frontend/src/app.d.ts
+++ b/src/platform_dashboard_frontend/src/app.d.ts
@@ -1,0 +1,4 @@
+declare global {
+  namespace App {}
+}
+export {};

--- a/src/platform_dashboard_frontend/src/app.html
+++ b/src/platform_dashboard_frontend/src/app.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <link rel="icon" href="%sveltekit.assets%/favicon.svg" type="image/svg+xml" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Platform Dashboard</title>
+  %sveltekit.head%
+</head>
+<body data-sveltekit-preload-data="hover">
+  <div style="display: contents">%sveltekit.body%</div>
+</body>
+</html>

--- a/src/platform_dashboard_frontend/src/lib/auth.ts
+++ b/src/platform_dashboard_frontend/src/lib/auth.ts
@@ -1,0 +1,58 @@
+import { AuthClient } from '@dfinity/auth-client';
+import type { Identity } from '@dfinity/agent';
+import type { Principal } from '@dfinity/principal';
+import { writable, type Writable } from 'svelte/store';
+
+import { CONFIG } from './config';
+
+let authClient: AuthClient | null = null;
+
+export const isAuthenticated: Writable<boolean> = writable(false);
+export const principalStore: Writable<Principal | null> = writable(null);
+
+async function ensureClient(): Promise<AuthClient> {
+  if (!authClient) authClient = await AuthClient.create();
+  return authClient;
+}
+
+export async function bootstrapAuth(): Promise<void> {
+  const client = await ensureClient();
+  if (await client.isAuthenticated()) {
+    const id = client.getIdentity();
+    isAuthenticated.set(true);
+    principalStore.set(id.getPrincipal());
+  }
+}
+
+export async function login(): Promise<{ identity: Identity | null; principal: Principal | null }> {
+  const client = await ensureClient();
+  return new Promise((resolve) => {
+    client.login({
+      identityProvider: CONFIG.internet_identity_url,
+      onSuccess: () => {
+        const identity = client.getIdentity();
+        const principal = identity.getPrincipal();
+        isAuthenticated.set(true);
+        principalStore.set(principal);
+        resolve({ identity, principal });
+      },
+      onError: (err) => {
+        console.error('II login failed:', err);
+        resolve({ identity: null, principal: null });
+      },
+    });
+  });
+}
+
+export async function logout(): Promise<void> {
+  const client = await ensureClient();
+  await client.logout();
+  isAuthenticated.set(false);
+  principalStore.set(null);
+}
+
+export async function getIdentity(): Promise<Identity | null> {
+  const client = await ensureClient();
+  if (await client.isAuthenticated()) return client.getIdentity();
+  return null;
+}

--- a/src/platform_dashboard_frontend/src/lib/canisters.ts
+++ b/src/platform_dashboard_frontend/src/lib/canisters.ts
@@ -1,0 +1,111 @@
+import { building } from '$app/environment';
+import { HttpAgent } from '@dfinity/agent';
+import { getIdentity } from './auth';
+import { CONFIG } from './config';
+
+const buildingOrTesting =
+  building || (typeof process !== 'undefined' && process.env?.NODE_ENV === 'test');
+
+function dummyActor(): any {
+  return new Proxy(
+    {},
+    {
+      get() {
+        throw new Error('Canister invoked during build');
+      },
+    },
+  );
+}
+
+function isLocalDevelopment(): boolean {
+  if (typeof window === 'undefined') return false;
+  return (
+    window.location.hostname.includes('localhost') ||
+    window.location.hostname.includes('127.0.0.1')
+  );
+}
+
+async function makeAgent(): Promise<HttpAgent> {
+  const identity = await getIdentity();
+  const agentOptions: any = identity ? { identity } : {};
+  const agent = new HttpAgent(agentOptions);
+  if (isLocalDevelopment()) {
+    try {
+      await agent.fetchRootKey();
+    } catch (e) {
+      console.warn('fetchRootKey failed (ok in local dev):', e);
+    }
+  }
+  return agent;
+}
+
+type ActorCache = { promise: Promise<any> | null; identityPrincipal: string | null };
+
+function makeLazyProxy(
+  importFn: () => Promise<{ createActor: any; canisterId: any }>,
+): { proxy: any; invalidate: () => void } {
+  const cache: ActorCache = { promise: null, identityPrincipal: null };
+
+  async function getActor() {
+    const id = await getIdentity();
+    const idStr = id ? id.getPrincipal().toText() : null;
+    if (cache.promise && cache.identityPrincipal === idStr) return cache.promise;
+    cache.identityPrincipal = idStr;
+    cache.promise = (async () => {
+      if (buildingOrTesting) return dummyActor();
+      const { createActor, canisterId } = await importFn();
+      const agent = await makeAgent();
+      return createActor(canisterId, { agent });
+    })();
+    return cache.promise;
+  }
+
+  const proxy = new Proxy({} as any, {
+    get(_target, prop: string) {
+      return async (...args: unknown[]) => {
+        const actor = await getActor();
+        const fn = (actor as any)[prop];
+        if (typeof fn !== 'function') {
+          throw new Error(`Actor has no method '${prop}'`);
+        }
+        return fn(...args);
+      };
+    },
+  });
+
+  return {
+    proxy,
+    invalidate() {
+      cache.promise = null;
+      cache.identityPrincipal = null;
+    },
+  };
+}
+
+const registry = makeLazyProxy(() => import('declarations/realm_registry_backend'));
+const installer = makeLazyProxy(() => import('declarations/realm_installer'));
+const marketplace = makeLazyProxy(() => import('declarations/marketplace_backend'));
+const fileRegistry = makeLazyProxy(() => import('declarations/file_registry'));
+
+export const registryActor = registry.proxy;
+export const installerActor = installer.proxy;
+export const marketplaceActor = marketplace.proxy;
+export const fileRegistryActor = fileRegistry.proxy;
+
+export function invalidateActors() {
+  registry.invalidate();
+  installer.invalidate();
+  marketplace.invalidate();
+  fileRegistry.invalidate();
+}
+
+/**
+ * Create an ad-hoc actor for a specific realm_backend canister by ID.
+ * Not cached -- each call creates a fresh actor with current identity.
+ */
+export async function createRealmBackendActor(canisterId: string): Promise<any> {
+  if (buildingOrTesting) return dummyActor();
+  const { createActor } = await import('declarations/realm_backend');
+  const agent = await makeAgent();
+  return createActor(canisterId, { agent });
+}

--- a/src/platform_dashboard_frontend/src/lib/config.test.ts
+++ b/src/platform_dashboard_frontend/src/lib/config.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { frontendUrl, candidUiUrl, icDashboardUrl, shortId } from './config';
+
+describe('frontendUrl', () => {
+  it('returns icp0.io URL for a canister ID', () => {
+    expect(frontendUrl('abc-def')).toBe('https://abc-def.icp0.io');
+  });
+});
+
+describe('candidUiUrl', () => {
+  it('returns Candid UI URL with the canister ID as query param', () => {
+    const url = candidUiUrl('xyz-123');
+    expect(url).toContain('a4gq6-oaaaa-aaaab-qaa4q-cai.raw.icp0.io');
+    expect(url).toContain('id=xyz-123');
+  });
+});
+
+describe('icDashboardUrl', () => {
+  it('returns IC Dashboard URL with the canister ID in the path', () => {
+    expect(icDashboardUrl('abc-def')).toBe(
+      'https://dashboard.internetcomputer.org/canister/abc-def',
+    );
+  });
+});
+
+describe('shortId', () => {
+  it('returns short IDs unchanged', () => {
+    expect(shortId('abc-def')).toBe('abc-def');
+  });
+
+  it('truncates long canister IDs with ellipsis', () => {
+    const long = 'rhw4p-gqaaa-aaaac-qbw7q-cai';
+    const short = shortId(long);
+    expect(short.length).toBeLessThan(long.length);
+    expect(short).toContain('...');
+    expect(short.startsWith(long.slice(0, 7))).toBe(true);
+    expect(short.endsWith(long.slice(-5))).toBe(true);
+  });
+
+  it('returns strings at the boundary length unchanged', () => {
+    const exactly15 = '123456789012345';
+    expect(shortId(exactly15)).toBe(exactly15);
+  });
+});

--- a/src/platform_dashboard_frontend/src/lib/config.ts
+++ b/src/platform_dashboard_frontend/src/lib/config.ts
@@ -1,0 +1,44 @@
+const env =
+  (typeof process !== 'undefined' && (process as any).env) || ({} as Record<string, string | undefined>);
+
+function pick(...keys: string[]): string {
+  for (const k of keys) {
+    const v = env[k];
+    if (v && String(v).trim() !== '') return String(v);
+  }
+  return '';
+}
+
+export const CONFIG = {
+  internet_identity_url:
+    pick('VITE_INTERNET_IDENTITY_URL') ||
+    (pick('CANISTER_ID_INTERNET_IDENTITY')
+      ? `http://${pick('CANISTER_ID_INTERNET_IDENTITY')}.localhost:4943`
+      : 'https://identity.ic0.app'),
+
+  realm_registry_backend_id: pick('CANISTER_ID_REALM_REGISTRY_BACKEND'),
+  realm_registry_frontend_id: pick('CANISTER_ID_REALM_REGISTRY_FRONTEND'),
+  realm_installer_id: pick('CANISTER_ID_REALM_INSTALLER'),
+  realm_installer_frontend_id: pick('CANISTER_ID_REALM_INSTALLER_FRONTEND'),
+  file_registry_id: pick('CANISTER_ID_FILE_REGISTRY'),
+  file_registry_frontend_id: pick('CANISTER_ID_FILE_REGISTRY_FRONTEND'),
+  marketplace_backend_id: pick('CANISTER_ID_MARKETPLACE_BACKEND'),
+  marketplace_frontend_id: pick('CANISTER_ID_MARKETPLACE_FRONTEND'),
+};
+
+export function frontendUrl(canisterId: string): string {
+  return `https://${canisterId}.icp0.io`;
+}
+
+export function candidUiUrl(canisterId: string): string {
+  return `https://a4gq6-oaaaa-aaaab-qaa4q-cai.raw.icp0.io/?id=${canisterId}`;
+}
+
+export function icDashboardUrl(canisterId: string): string {
+  return `https://dashboard.internetcomputer.org/canister/${canisterId}`;
+}
+
+export function shortId(id: string): string {
+  if (id.length <= 15) return id;
+  return id.slice(0, 7) + '...' + id.slice(-5);
+}

--- a/src/platform_dashboard_frontend/src/lib/types.test.ts
+++ b/src/platform_dashboard_frontend/src/lib/types.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import type {
+  RealmRecord,
+  CanisterInfo,
+  QuarterInfoRecord,
+  StatusRecord,
+  DeployRecord,
+  DeployStepRecord,
+  DeployStatusRecord,
+  FileRegistryStats,
+  InstallerInfo,
+} from './types';
+
+describe('type contracts', () => {
+  it('RealmRecord has the expected shape', () => {
+    const record: RealmRecord = {
+      id: 'abc-123',
+      name: 'Test Realm',
+      url: 'https://abc-123.icp0.io',
+      backend_url: 'https://abc-123.raw.icp0.io',
+      logo: '',
+      users_count: 42,
+      created_at: '2025-01-01',
+    };
+    expect(record.id).toBe('abc-123');
+    expect(record.users_count).toBe(42);
+  });
+
+  it('CanisterInfo has id and type', () => {
+    const info: CanisterInfo = { canister_id: 'xyz', canister_type: 'backend' };
+    expect(info.canister_type).toBe('backend');
+  });
+
+  it('QuarterInfoRecord has population and status', () => {
+    const q: QuarterInfoRecord = {
+      name: 'Q1',
+      canister_id: 'q1-id',
+      population: 100,
+      status: 'active',
+    };
+    expect(q.population).toBe(100);
+  });
+
+  it('StatusRecord supports optional fields', () => {
+    const status: StatusRecord = { version: '1.0.0' };
+    expect(status.version).toBe('1.0.0');
+    expect(status.quarters).toBeUndefined();
+  });
+
+  it('DeployRecord captures deployment metadata', () => {
+    const d: DeployRecord = {
+      deploy_id: 'd-1',
+      realm_name: 'Dominion',
+      status: 'completed',
+      started_at: '2025-01-01T00:00:00Z',
+      completed_at: '2025-01-01T00:05:00Z',
+    };
+    expect(d.status).toBe('completed');
+  });
+
+  it('DeployStatusRecord contains steps', () => {
+    const step: DeployStepRecord = {
+      step: 1,
+      name: 'Upload WASM',
+      status: 'done',
+    };
+    const ds: DeployStatusRecord = {
+      deploy_id: 'd-1',
+      realm_name: 'Dominion',
+      status: 'completed',
+      steps: [step],
+    };
+    expect(ds.steps).toHaveLength(1);
+    expect(ds.steps[0].name).toBe('Upload WASM');
+  });
+
+  it('FileRegistryStats has numeric fields', () => {
+    const stats: FileRegistryStats = {
+      total_files: 10,
+      total_bytes: 1024,
+      total_chunks: 5,
+    };
+    expect(stats.total_bytes).toBe(1024);
+  });
+
+  it('InstallerInfo has version', () => {
+    const info: InstallerInfo = { version: '2.0.0', commit: 'abc1234' };
+    expect(info.version).toBe('2.0.0');
+  });
+});

--- a/src/platform_dashboard_frontend/src/lib/types.ts
+++ b/src/platform_dashboard_frontend/src/lib/types.ts
@@ -1,0 +1,75 @@
+export interface RealmRecord {
+  id: string;
+  name: string;
+  url: string;
+  backend_url: string;
+  logo: string;
+  users_count: number;
+  created_at: string;
+}
+
+export interface CanisterInfo {
+  canister_id: string;
+  canister_type: string;
+  name?: string;
+}
+
+export interface QuarterInfoRecord {
+  name: string;
+  canister_id: string;
+  population: number;
+  status: string;
+}
+
+export interface StatusRecord {
+  version?: string;
+  commit?: string;
+  canisters?: CanisterInfo[];
+  quarters?: QuarterInfoRecord[];
+  registries?: CanisterInfo[];
+  users_count?: number;
+  objects_count?: number;
+  extensions?: string[];
+  realms_count?: number;
+  dependencies?: Record<string, string>;
+  is_caller_controller?: boolean;
+  [key: string]: any;
+}
+
+export interface DeployRecord {
+  deploy_id: string;
+  realm_name: string;
+  status: string;
+  started_at: string;
+  completed_at?: string;
+  error?: string;
+}
+
+export interface DeployStepRecord {
+  step: number;
+  name: string;
+  status: string;
+  started_at?: string;
+  completed_at?: string;
+  log?: string;
+}
+
+export interface DeployStatusRecord {
+  deploy_id: string;
+  realm_name: string;
+  status: string;
+  steps: DeployStepRecord[];
+  error?: string;
+}
+
+export interface FileRegistryStats {
+  total_files: number;
+  total_bytes: number;
+  total_chunks: number;
+}
+
+export interface InstallerInfo {
+  version: string;
+  commit?: string;
+  [key: string]: any;
+}

--- a/src/platform_dashboard_frontend/src/routes/+layout.js
+++ b/src/platform_dashboard_frontend/src/routes/+layout.js
@@ -1,0 +1,2 @@
+export const prerender = false;
+export const ssr = false;

--- a/src/platform_dashboard_frontend/src/routes/+layout.svelte
+++ b/src/platform_dashboard_frontend/src/routes/+layout.svelte
@@ -1,0 +1,254 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { browser } from '$app/environment';
+  import { page } from '$app/stores';
+  import '../app.css';
+
+  import { bootstrapAuth, isAuthenticated, login, logout, principalStore } from '$lib/auth';
+  import { invalidateActors } from '$lib/canisters';
+
+  let booted = false;
+  let sidebarOpen = false;
+
+  onMount(async () => {
+    if (!browser) return;
+    await bootstrapAuth();
+    booted = true;
+  });
+
+  async function handleLogin() {
+    await login();
+    invalidateActors();
+  }
+
+  async function handleLogout() {
+    await logout();
+    invalidateActors();
+  }
+
+  function shortPrincipal(text: string): string {
+    if (text.length <= 15) return text;
+    return text.slice(0, 7) + '...' + text.slice(-5);
+  }
+
+  $: routeIsActive = (path: string) => {
+    if (path === '/') return $page.url.pathname === '/';
+    return $page.url.pathname.startsWith(path);
+  };
+
+  const navItems = [
+    { href: '/',          label: 'Dashboard',  icon: '⊞' },
+    { href: '/platform',  label: 'Platform',   icon: '⚙' },
+    { href: '/realms',    label: 'Realms',     icon: '◎' },
+    { href: '/installer', label: 'Installer',  icon: '⟐' },
+  ];
+</script>
+
+<div class="shell" class:sidebar-open={sidebarOpen}>
+  <aside class="sidebar">
+    <div class="sidebar-brand">
+      <span class="brand-icon">◈</span>
+      <span class="brand-text">Platform</span>
+    </div>
+    <nav class="sidebar-nav">
+      {#each navItems as item}
+        <a
+          href={item.href}
+          class="nav-item"
+          class:active={routeIsActive(item.href)}
+          on:click={() => sidebarOpen = false}
+        >
+          <span class="nav-icon">{item.icon}</span>
+          <span>{item.label}</span>
+        </a>
+      {/each}
+    </nav>
+    <div class="sidebar-footer">
+      {#if !booted}
+        <span class="muted">Loading...</span>
+      {:else if $isAuthenticated && $principalStore}
+        <div class="auth-info">
+          <span class="who" title={$principalStore.toText()}>
+            {shortPrincipal($principalStore.toText())}
+          </span>
+          <button class="btn btn-sm" on:click={handleLogout}>Sign out</button>
+        </div>
+      {:else}
+        <button class="btn btn-primary btn-sm" style="width:100%" on:click={handleLogin}>
+          Sign in
+        </button>
+      {/if}
+    </div>
+  </aside>
+
+  <div class="main-area">
+    <header class="topbar">
+      <button class="hamburger" on:click={() => sidebarOpen = !sidebarOpen} aria-label="Toggle menu">
+        <span></span><span></span><span></span>
+      </button>
+      <h1 class="topbar-title">
+        {#each navItems as item}
+          {#if routeIsActive(item.href)}
+            {item.label}
+          {/if}
+        {/each}
+      </h1>
+      <div class="topbar-auth">
+        {#if booted && !$isAuthenticated}
+          <button class="btn btn-primary btn-sm" on:click={handleLogin}>Sign in</button>
+        {:else if booted && $isAuthenticated && $principalStore}
+          <span class="who-topbar">{shortPrincipal($principalStore.toText())}</span>
+        {/if}
+      </div>
+    </header>
+    <main class="content">
+      <slot />
+    </main>
+  </div>
+</div>
+
+{#if sidebarOpen}
+  <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
+  <div class="overlay" on:click={() => sidebarOpen = false}></div>
+{/if}
+
+<style>
+  .shell {
+    display: flex;
+    min-height: 100vh;
+  }
+
+  /* Sidebar */
+  .sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: var(--sidebar-width);
+    background: var(--surface);
+    border-right: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    z-index: 40;
+    transition: transform 0.2s ease;
+  }
+  .sidebar-brand {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 1rem 1.25rem;
+    font-weight: 700;
+    font-size: 1.05rem;
+    border-bottom: 1px solid var(--border);
+  }
+  .brand-icon { font-size: 1.3rem; }
+  .sidebar-nav {
+    flex: 1;
+    padding: 0.75rem 0.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+  .nav-item {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    padding: 0.6rem 0.75rem;
+    border-radius: 0.5rem;
+    color: var(--text-muted);
+    text-decoration: none;
+    font-size: 0.9rem;
+    transition: all 0.12s ease;
+  }
+  .nav-item:hover { background: var(--surface-2); color: var(--text); }
+  .nav-item.active { background: var(--primary-light); color: var(--primary); font-weight: 600; }
+  .nav-icon { font-size: 1.1rem; width: 1.3rem; text-align: center; }
+
+  .sidebar-footer {
+    padding: 1rem 1.25rem;
+    border-top: 1px solid var(--border);
+  }
+  .auth-info {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+  }
+  .who {
+    font-family: monospace;
+    font-size: 0.78rem;
+    color: var(--text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  /* Main */
+  .main-area {
+    flex: 1;
+    margin-left: var(--sidebar-width);
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+  }
+  .topbar {
+    position: sticky;
+    top: 0;
+    z-index: 30;
+    height: var(--topbar-height);
+    display: flex;
+    align-items: center;
+    padding: 0 1.5rem;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+    gap: 1rem;
+  }
+  .topbar-title {
+    font-size: 1rem;
+    font-weight: 600;
+    margin: 0;
+    flex: 1;
+  }
+  .topbar-auth { display: flex; align-items: center; gap: 0.5rem; }
+  .who-topbar { font-family: monospace; font-size: 0.8rem; color: var(--text-muted); }
+
+  .content {
+    flex: 1;
+    padding: 1.75rem 2rem 3rem;
+    max-width: 1200px;
+    width: 100%;
+  }
+
+  .hamburger {
+    display: none;
+    flex-direction: column;
+    gap: 4px;
+    background: none;
+    border: none;
+    padding: 4px;
+    cursor: pointer;
+  }
+  .hamburger span {
+    width: 20px;
+    height: 2px;
+    background: var(--text-muted);
+    border-radius: 1px;
+  }
+
+  .overlay {
+    display: none;
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.3);
+    z-index: 35;
+  }
+  .muted { color: var(--text-faint); font-size: 0.85rem; }
+
+  @media (max-width: 768px) {
+    .sidebar { transform: translateX(-100%); }
+    .shell.sidebar-open .sidebar { transform: translateX(0); }
+    .main-area { margin-left: 0; }
+    .hamburger { display: flex; }
+    .overlay { display: block; }
+    .content { padding: 1.25rem 1rem 2rem; }
+  }
+</style>

--- a/src/platform_dashboard_frontend/src/routes/+page.svelte
+++ b/src/platform_dashboard_frontend/src/routes/+page.svelte
@@ -1,0 +1,160 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { registryActor, marketplaceActor, fileRegistryActor, installerActor } from '$lib/canisters';
+  import type { StatusRecord, FileRegistryStats } from '$lib/types';
+
+  let loading = true;
+  let error = '';
+  let realmsCount = 0;
+  let marketplaceStats: Record<string, any> = {};
+  let fileStats: FileRegistryStats | null = null;
+  let installerHealthy = false;
+
+  onMount(async () => {
+    try {
+      const results = await Promise.allSettled([
+        registryActor.status(),
+        marketplaceActor.status(),
+        fileRegistryActor.get_stats(),
+        installerActor.health(),
+      ]);
+
+      if (results[0].status === 'fulfilled') {
+        const s = results[0].value?.Ok ?? results[0].value;
+        realmsCount = s?.realms_count ?? 0;
+      }
+
+      if (results[1].status === 'fulfilled') {
+        const s = results[1].value?.Ok ?? results[1].value;
+        marketplaceStats = s ?? {};
+      }
+
+      if (results[2].status === 'fulfilled') {
+        const raw = results[2].value?.Ok ?? results[2].value;
+        try {
+          fileStats = typeof raw === 'string' ? JSON.parse(raw) : raw;
+        } catch { fileStats = null; }
+      }
+
+      if (results[3].status === 'fulfilled') {
+        installerHealthy = true;
+      }
+    } catch (e: any) {
+      error = e.message || 'Failed to load dashboard data';
+    } finally {
+      loading = false;
+    }
+  });
+
+  function formatBytes(bytes: number): string {
+    if (bytes === 0) return '0 B';
+    const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(1024));
+    return (bytes / Math.pow(1024, i)).toFixed(1) + ' ' + units[i];
+  }
+</script>
+
+<h1 class="page-title">Dashboard</h1>
+<p class="page-subtitle">Platform overview across all subsystems</p>
+
+{#if loading}
+  <div class="empty-state"><span class="spinner"></span> Loading...</div>
+{:else if error}
+  <div class="card" style="border-color: var(--danger); color: var(--danger);">{error}</div>
+{:else}
+  <div class="stat-grid">
+    <div class="stat-card">
+      <div class="stat-value">{realmsCount}</div>
+      <div class="stat-label">Realms Registered</div>
+    </div>
+
+    <div class="stat-card">
+      <div class="stat-value">{marketplaceStats.extensions_count ?? '—'}</div>
+      <div class="stat-label">Marketplace Extensions</div>
+    </div>
+
+    <div class="stat-card">
+      <div class="stat-value">{marketplaceStats.codices_count ?? '—'}</div>
+      <div class="stat-label">Codices</div>
+    </div>
+
+    <div class="stat-card">
+      <div class="stat-value">{marketplaceStats.assistants_count ?? '—'}</div>
+      <div class="stat-label">Assistants</div>
+    </div>
+
+    <div class="stat-card">
+      <div class="stat-value">
+        {fileStats ? formatBytes(fileStats.total_bytes) : '—'}
+      </div>
+      <div class="stat-label">File Registry Storage</div>
+    </div>
+
+    <div class="stat-card">
+      <div class="stat-value">{fileStats?.total_files ?? '—'}</div>
+      <div class="stat-label">Files Stored</div>
+    </div>
+
+    <div class="stat-card">
+      <div class="stat-value">
+        <span class="badge" class:badge-success={installerHealthy} class:badge-danger={!installerHealthy}>
+          {installerHealthy ? 'Healthy' : 'Unreachable'}
+        </span>
+      </div>
+      <div class="stat-label">Installer Status</div>
+    </div>
+
+    <div class="stat-card">
+      <div class="stat-value">4</div>
+      <div class="stat-label">Platform Subsystems</div>
+    </div>
+  </div>
+
+  <h2 style="font-size: 1.1rem; margin-bottom: 1rem;">Quick Links</h2>
+  <div class="quick-links">
+    <a href="/platform" class="card quick-link">
+      <span class="ql-icon">⚙</span>
+      <span class="ql-text">
+        <strong>Platform Canisters</strong>
+        <span>Registry, Installer, Marketplace, File Registry</span>
+      </span>
+    </a>
+    <a href="/realms" class="card quick-link">
+      <span class="ql-icon">◎</span>
+      <span class="ql-text">
+        <strong>Browse Realms</strong>
+        <span>{realmsCount} realm{realmsCount !== 1 ? 's' : ''} registered</span>
+      </span>
+    </a>
+    <a href="/installer" class="card quick-link">
+      <span class="ql-icon">⟐</span>
+      <span class="ql-text">
+        <strong>Installer</strong>
+        <span>Deployments and health status</span>
+      </span>
+    </a>
+  </div>
+{/if}
+
+<style>
+  .quick-links {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 1rem;
+  }
+  .quick-link {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    text-decoration: none;
+    cursor: pointer;
+  }
+  .ql-icon { font-size: 1.6rem; }
+  .ql-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+  .ql-text strong { font-size: 0.95rem; }
+  .ql-text span { font-size: 0.8rem; color: var(--text-muted); }
+</style>

--- a/src/platform_dashboard_frontend/src/routes/installer/+page.svelte
+++ b/src/platform_dashboard_frontend/src/routes/installer/+page.svelte
@@ -1,0 +1,128 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { installerActor } from '$lib/canisters';
+  import type { DeployRecord, InstallerInfo } from '$lib/types';
+
+  let loading = true;
+  let error = '';
+  let healthy = false;
+  let info: InstallerInfo | null = null;
+  let deploys: DeployRecord[] = [];
+
+  onMount(async () => {
+    try {
+      const results = await Promise.allSettled([
+        installerActor.health(),
+        installerActor.info(),
+        installerActor.list_deploys(),
+      ]);
+
+      if (results[0].status === 'fulfilled') healthy = true;
+
+      if (results[1].status === 'fulfilled') {
+        const raw = results[1].value;
+        try {
+          info = typeof raw === 'string' ? JSON.parse(raw) : (raw?.Ok ? JSON.parse(raw.Ok) : raw);
+        } catch { info = null; }
+      }
+
+      if (results[2].status === 'fulfilled') {
+        const raw = results[2].value;
+        try {
+          const parsed = typeof raw === 'string' ? JSON.parse(raw) : (raw?.Ok ? JSON.parse(raw.Ok) : raw);
+          deploys = Array.isArray(parsed) ? parsed : [];
+        } catch { deploys = []; }
+      }
+    } catch (e: any) {
+      error = e.message || 'Failed to load installer data';
+    } finally {
+      loading = false;
+    }
+  });
+
+  function statusBadgeClass(status: string): string {
+    switch (status?.toLowerCase()) {
+      case 'completed': case 'success': return 'badge-success';
+      case 'in_progress': case 'in-progress': case 'running': return 'badge-warning';
+      case 'failed': case 'error': return 'badge-danger';
+      case 'pending': case 'queued': return 'badge-info';
+      default: return 'badge-neutral';
+    }
+  }
+</script>
+
+<h1 class="page-title">Installer</h1>
+<p class="page-subtitle">Realm deployment management and monitoring</p>
+
+{#if loading}
+  <div class="empty-state"><span class="spinner"></span> Loading installer data...</div>
+{:else if error}
+  <div class="card" style="border-color: var(--danger); color: var(--danger);">{error}</div>
+{:else}
+  <div class="stat-grid">
+    <div class="stat-card">
+      <div class="stat-value">
+        <span class="badge" class:badge-success={healthy} class:badge-danger={!healthy}>
+          {healthy ? 'Healthy' : 'Unreachable'}
+        </span>
+      </div>
+      <div class="stat-label">Health Status</div>
+    </div>
+    {#if info?.version}
+      <div class="stat-card">
+        <div class="stat-value" style="font-size:1.1rem">{info.version}</div>
+        <div class="stat-label">Version</div>
+      </div>
+    {/if}
+    {#if info?.commit}
+      <div class="stat-card">
+        <div class="stat-value" style="font-size:1.1rem; font-family:monospace">{info.commit}</div>
+        <div class="stat-label">Commit</div>
+      </div>
+    {/if}
+    <div class="stat-card">
+      <div class="stat-value">{deploys.length}</div>
+      <div class="stat-label">Total Deployments</div>
+    </div>
+  </div>
+
+  <h2 style="font-size: 1.1rem; margin: 1.5rem 0 0.75rem;">Deployments</h2>
+
+  {#if deploys.length === 0}
+    <div class="empty-state">No deployments recorded.</div>
+  {:else}
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>Deploy ID</th>
+            <th>Realm</th>
+            <th>Status</th>
+            <th>Started</th>
+            <th>Completed</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each deploys as d}
+            <tr>
+              <td><code>{d.deploy_id}</code></td>
+              <td>{d.realm_name || '—'}</td>
+              <td><span class="badge {statusBadgeClass(d.status)}">{d.status}</span></td>
+              <td>{d.started_at || '—'}</td>
+              <td>{d.completed_at || '—'}</td>
+              <td>
+                <a href="/installer/{d.deploy_id}" class="btn btn-sm">Details</a>
+              </td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </div>
+  {/if}
+{/if}
+
+<style>
+  .table-wrap { overflow-x: auto; border: 1px solid var(--border); border-radius: 0.5rem; }
+  .table-wrap table { margin: 0; }
+</style>

--- a/src/platform_dashboard_frontend/src/routes/installer/[deployId]/+page.svelte
+++ b/src/platform_dashboard_frontend/src/routes/installer/[deployId]/+page.svelte
@@ -1,0 +1,196 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { page } from '$app/stores';
+  import { installerActor } from '$lib/canisters';
+  import type { DeployStatusRecord, DeployStepRecord } from '$lib/types';
+
+  let loading = true;
+  let error = '';
+  let deployStatus: DeployStatusRecord | null = null;
+
+  $: deployId = $page.params.deployId;
+
+  onMount(async () => {
+    try {
+      const raw = await installerActor.get_deploy_status(deployId);
+      const parsed = typeof raw === 'string' ? JSON.parse(raw) : (raw?.Ok ? JSON.parse(raw.Ok) : raw);
+      deployStatus = parsed;
+    } catch (e: any) {
+      error = e.message || 'Failed to load deployment status';
+    } finally {
+      loading = false;
+    }
+  });
+
+  function statusBadgeClass(status: string): string {
+    switch (status?.toLowerCase()) {
+      case 'completed': case 'success': case 'done': return 'badge-success';
+      case 'in_progress': case 'in-progress': case 'running': return 'badge-warning';
+      case 'failed': case 'error': return 'badge-danger';
+      case 'pending': case 'queued': case 'waiting': return 'badge-info';
+      case 'skipped': return 'badge-neutral';
+      default: return 'badge-neutral';
+    }
+  }
+
+  function stepIcon(status: string): string {
+    switch (status?.toLowerCase()) {
+      case 'completed': case 'success': case 'done': return '✓';
+      case 'in_progress': case 'in-progress': case 'running': return '●';
+      case 'failed': case 'error': return '✗';
+      case 'skipped': return '—';
+      default: return '○';
+    }
+  }
+</script>
+
+<div class="breadcrumb">
+  <a href="/installer">Installer</a>
+  <span class="sep">/</span>
+  <span>{deployId}</span>
+</div>
+
+<h1 class="page-title">Deployment Details</h1>
+
+{#if loading}
+  <div class="empty-state"><span class="spinner"></span> Loading deployment status...</div>
+{:else if error}
+  <div class="card" style="border-color: var(--danger); color: var(--danger);">{error}</div>
+{:else if deployStatus}
+  <div class="stat-grid">
+    <div class="stat-card">
+      <div class="stat-value" style="font-size:1rem; font-family:monospace">{deployStatus.deploy_id}</div>
+      <div class="stat-label">Deploy ID</div>
+    </div>
+    {#if deployStatus.realm_name}
+      <div class="stat-card">
+        <div class="stat-value" style="font-size:1.1rem">{deployStatus.realm_name}</div>
+        <div class="stat-label">Realm</div>
+      </div>
+    {/if}
+    <div class="stat-card">
+      <div class="stat-value">
+        <span class="badge {statusBadgeClass(deployStatus.status)}">{deployStatus.status}</span>
+      </div>
+      <div class="stat-label">Overall Status</div>
+    </div>
+  </div>
+
+  {#if deployStatus.error}
+    <div class="card error-card">
+      <strong>Error:</strong> {deployStatus.error}
+    </div>
+  {/if}
+
+  <h2 style="font-size: 1.1rem; margin: 1.5rem 0 0.75rem;">
+    Steps ({deployStatus.steps?.length ?? 0})
+  </h2>
+
+  {#if deployStatus.steps && deployStatus.steps.length > 0}
+    <div class="steps">
+      {#each deployStatus.steps as step, i}
+        <div class="step" class:step-active={['in_progress','in-progress','running'].includes(step.status?.toLowerCase())}>
+          <div class="step-indicator">
+            <span class="step-icon {statusBadgeClass(step.status)}">{stepIcon(step.status)}</span>
+            {#if i < deployStatus.steps.length - 1}
+              <div class="step-line"></div>
+            {/if}
+          </div>
+          <div class="step-body">
+            <div class="step-header">
+              <span class="step-name">{step.name}</span>
+              <span class="badge {statusBadgeClass(step.status)}">{step.status}</span>
+            </div>
+            {#if step.started_at || step.completed_at}
+              <div class="step-times">
+                {#if step.started_at}<span>Started: {step.started_at}</span>{/if}
+                {#if step.completed_at}<span>Completed: {step.completed_at}</span>{/if}
+              </div>
+            {/if}
+            {#if step.log}
+              <pre class="step-log">{step.log}</pre>
+            {/if}
+          </div>
+        </div>
+      {/each}
+    </div>
+  {:else}
+    <div class="empty-state">No step information available.</div>
+  {/if}
+{:else}
+  <div class="empty-state">Deployment not found.</div>
+{/if}
+
+<style>
+  .breadcrumb {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    margin-bottom: 0.75rem;
+  }
+  .breadcrumb a { color: var(--primary); text-decoration: none; }
+  .breadcrumb a:hover { text-decoration: underline; }
+  .sep { margin: 0 0.4rem; color: var(--text-faint); }
+
+  .error-card {
+    border-color: var(--danger);
+    color: var(--danger);
+    margin-bottom: 1rem;
+  }
+
+  .steps { display: flex; flex-direction: column; }
+  .step {
+    display: flex;
+    gap: 0.85rem;
+    min-height: 3rem;
+  }
+  .step-active { background: var(--surface-2); border-radius: 0.5rem; padding: 0.5rem; margin: -0.5rem; margin-bottom: 0; }
+
+  .step-indicator {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    flex-shrink: 0;
+    width: 1.5rem;
+  }
+  .step-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 50%;
+    font-size: 0.75rem;
+    font-weight: 700;
+    flex-shrink: 0;
+  }
+  .step-line {
+    width: 2px;
+    flex: 1;
+    background: var(--border);
+    margin: 0.25rem 0;
+  }
+
+  .step-body {
+    flex: 1;
+    padding-bottom: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+  .step-header { display: flex; align-items: center; gap: 0.5rem; }
+  .step-name { font-weight: 600; font-size: 0.9rem; }
+  .step-times { font-size: 0.78rem; color: var(--text-faint); display: flex; gap: 1rem; }
+  .step-log {
+    margin: 0.35rem 0 0;
+    padding: 0.65rem 0.85rem;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 0.375rem;
+    font-size: 0.78rem;
+    overflow-x: auto;
+    white-space: pre-wrap;
+    word-break: break-all;
+    max-height: 200px;
+    overflow-y: auto;
+  }
+</style>

--- a/src/platform_dashboard_frontend/src/routes/platform/+page.svelte
+++ b/src/platform_dashboard_frontend/src/routes/platform/+page.svelte
@@ -1,0 +1,188 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { registryActor, installerActor, marketplaceActor, fileRegistryActor } from '$lib/canisters';
+  import { CONFIG, frontendUrl, candidUiUrl, icDashboardUrl, shortId } from '$lib/config';
+  import type { StatusRecord, FileRegistryStats, InstallerInfo } from '$lib/types';
+
+  interface SubsystemInfo {
+    name: string;
+    backendId: string;
+    frontendId: string;
+    status: StatusRecord | null;
+    extra: Record<string, any>;
+    loading: boolean;
+    error: string;
+  }
+
+  let subsystems: SubsystemInfo[] = [
+    { name: 'Realm Registry', backendId: CONFIG.realm_registry_backend_id, frontendId: CONFIG.realm_registry_frontend_id, status: null, extra: {}, loading: true, error: '' },
+    { name: 'Realm Installer', backendId: CONFIG.realm_installer_id, frontendId: CONFIG.realm_installer_frontend_id, status: null, extra: {}, loading: true, error: '' },
+    { name: 'Marketplace', backendId: CONFIG.marketplace_backend_id, frontendId: CONFIG.marketplace_frontend_id, status: null, extra: {}, loading: true, error: '' },
+    { name: 'File Registry', backendId: CONFIG.file_registry_id, frontendId: CONFIG.file_registry_frontend_id, status: null, extra: {}, loading: true, error: '' },
+  ];
+
+  onMount(async () => {
+    const fetchers = [
+      async () => {
+        try {
+          const raw = await registryActor.status();
+          subsystems[0].status = raw?.Ok ?? raw;
+        } catch (e: any) { subsystems[0].error = e.message; }
+        subsystems[0].loading = false;
+        subsystems = subsystems;
+      },
+      async () => {
+        try {
+          const [health, info] = await Promise.all([
+            installerActor.health().catch(() => null),
+            installerActor.info().catch(() => null),
+          ]);
+          subsystems[1].extra = { healthy: !!health };
+          if (info) {
+            const parsed = typeof info === 'string' ? JSON.parse(info) : (info?.Ok ? JSON.parse(info.Ok) : info);
+            subsystems[1].status = parsed;
+          }
+        } catch (e: any) { subsystems[1].error = e.message; }
+        subsystems[1].loading = false;
+        subsystems = subsystems;
+      },
+      async () => {
+        try {
+          const raw = await marketplaceActor.status();
+          subsystems[2].status = raw?.Ok ?? raw;
+        } catch (e: any) { subsystems[2].error = e.message; }
+        subsystems[2].loading = false;
+        subsystems = subsystems;
+      },
+      async () => {
+        try {
+          const raw = await fileRegistryActor.get_stats();
+          const parsed = typeof raw === 'string' ? JSON.parse(raw) : (raw?.Ok ? JSON.parse(raw.Ok) : raw);
+          subsystems[3].extra = { stats: parsed };
+        } catch (e: any) { subsystems[3].error = e.message; }
+        subsystems[3].loading = false;
+        subsystems = subsystems;
+      },
+    ];
+    await Promise.allSettled(fetchers.map(f => f()));
+  });
+</script>
+
+<h1 class="page-title">Platform Infrastructure</h1>
+<p class="page-subtitle">Core canister subsystems powering the platform</p>
+
+<div class="grid">
+  {#each subsystems as sub}
+    <div class="card subsystem-card">
+      <div class="sub-header">
+        <h3 class="sub-name">{sub.name}</h3>
+        {#if sub.loading}
+          <span class="badge badge-neutral"><span class="spinner" style="width:0.8em;height:0.8em;"></span></span>
+        {:else if sub.error}
+          <span class="badge badge-danger">Error</span>
+        {:else}
+          <span class="badge badge-success">Online</span>
+        {/if}
+      </div>
+
+      {#if sub.status?.version}
+        <div class="sub-meta">v{sub.status.version}</div>
+      {/if}
+      {#if sub.status?.commit}
+        <div class="sub-meta">Commit: {sub.status.commit}</div>
+      {/if}
+
+      {#if sub.name === 'Realm Registry' && sub.status?.realms_count != null}
+        <div class="sub-stat">{sub.status.realms_count} realms</div>
+      {/if}
+
+      {#if sub.name === 'Marketplace' && sub.status}
+        <div class="sub-stat">
+          {sub.status.extensions_count ?? 0} extensions,
+          {sub.status.codices_count ?? 0} codices,
+          {sub.status.assistants_count ?? 0} assistants
+        </div>
+      {/if}
+
+      {#if sub.name === 'Realm Installer'}
+        <div class="sub-stat">
+          Health: <span class="badge" class:badge-success={sub.extra.healthy} class:badge-danger={!sub.extra.healthy}>
+            {sub.extra.healthy ? 'OK' : 'Down'}
+          </span>
+        </div>
+      {/if}
+
+      {#if sub.name === 'File Registry' && sub.extra.stats}
+        <div class="sub-stat">
+          {sub.extra.stats.total_files ?? 0} files,
+          {sub.extra.stats.total_chunks ?? 0} chunks
+        </div>
+      {/if}
+
+      {#if sub.error}
+        <div class="sub-error">{sub.error}</div>
+      {/if}
+
+      <div class="sub-links">
+        {#if sub.backendId}
+          <div class="canister-row">
+            <span class="canister-label">Backend</span>
+            <code class="canister-id">{shortId(sub.backendId)}</code>
+            <a href={candidUiUrl(sub.backendId)} target="_blank" rel="noreferrer" class="link-external">Candid</a>
+            <a href={icDashboardUrl(sub.backendId)} target="_blank" rel="noreferrer" class="link-external">IC Dashboard</a>
+          </div>
+        {/if}
+        {#if sub.frontendId}
+          <div class="canister-row">
+            <span class="canister-label">Frontend</span>
+            <code class="canister-id">{shortId(sub.frontendId)}</code>
+            <a href={frontendUrl(sub.frontendId)} target="_blank" rel="noreferrer" class="link-external">Open</a>
+            <a href={icDashboardUrl(sub.frontendId)} target="_blank" rel="noreferrer" class="link-external">IC Dashboard</a>
+          </div>
+        {/if}
+      </div>
+    </div>
+  {/each}
+</div>
+
+<style>
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 1rem;
+  }
+  .subsystem-card { display: flex; flex-direction: column; gap: 0.5rem; }
+  .sub-header { display: flex; align-items: center; justify-content: space-between; }
+  .sub-name { font-size: 1.05rem; margin: 0; font-weight: 600; }
+  .sub-meta { font-size: 0.78rem; color: var(--text-faint); font-family: monospace; }
+  .sub-stat { font-size: 0.85rem; color: var(--text-muted); }
+  .sub-error { font-size: 0.8rem; color: var(--danger); }
+  .sub-links {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    margin-top: 0.5rem;
+    padding-top: 0.5rem;
+    border-top: 1px solid var(--border);
+  }
+  .canister-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+  .canister-label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    color: var(--text-faint);
+    width: 5rem;
+  }
+  .canister-id {
+    font-size: 0.78rem;
+    color: var(--text-muted);
+    background: var(--surface-2);
+    padding: 0.15em 0.4em;
+    border-radius: 0.25rem;
+  }
+</style>

--- a/src/platform_dashboard_frontend/src/routes/realms/+page.svelte
+++ b/src/platform_dashboard_frontend/src/routes/realms/+page.svelte
@@ -1,0 +1,163 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { registryActor } from '$lib/canisters';
+  import { frontendUrl, candidUiUrl, icDashboardUrl, shortId } from '$lib/config';
+  import type { RealmRecord } from '$lib/types';
+
+  let loading = true;
+  let error = '';
+  let allRealms: RealmRecord[] = [];
+  let search = '';
+  let currentPage = 0;
+  const pageSize = 20;
+  let expandedId: string | null = null;
+
+  $: filtered = allRealms.filter(r =>
+    r.name.toLowerCase().includes(search.toLowerCase()) ||
+    r.id.toLowerCase().includes(search.toLowerCase())
+  );
+  $: totalPages = Math.max(1, Math.ceil(filtered.length / pageSize));
+  $: pageRealms = filtered.slice(currentPage * pageSize, (currentPage + 1) * pageSize);
+
+  onMount(async () => {
+    try {
+      const raw = await registryActor.list_realms();
+      const list = raw?.Ok ?? raw;
+      allRealms = Array.isArray(list) ? list : [];
+    } catch (e: any) {
+      error = e.message || 'Failed to load realms';
+    } finally {
+      loading = false;
+    }
+  });
+
+  function toggleExpand(id: string) {
+    expandedId = expandedId === id ? null : id;
+  }
+</script>
+
+<h1 class="page-title">Realms</h1>
+<p class="page-subtitle">{allRealms.length} realm{allRealms.length !== 1 ? 's' : ''} registered</p>
+
+<div class="toolbar">
+  <input type="search" placeholder="Search realms by name or canister ID..." bind:value={search} on:input={() => currentPage = 0} />
+</div>
+
+{#if loading}
+  <div class="empty-state"><span class="spinner"></span> Loading realms...</div>
+{:else if error}
+  <div class="card" style="border-color: var(--danger); color: var(--danger);">{error}</div>
+{:else if filtered.length === 0}
+  <div class="empty-state">No realms found{search ? ' matching "' + search + '"' : ''}.</div>
+{:else}
+  <div class="realm-list">
+    {#each pageRealms as realm (realm.id)}
+      <div class="card realm-card">
+        <button class="realm-header" on:click={() => toggleExpand(realm.id)}>
+          <div class="realm-info">
+            {#if realm.logo}
+              <img src={realm.logo} alt="" class="realm-logo" />
+            {:else}
+              <div class="realm-logo placeholder">◎</div>
+            {/if}
+            <div>
+              <div class="realm-name">{realm.name}</div>
+              <code class="realm-id">{shortId(realm.id)}</code>
+            </div>
+          </div>
+          <div class="realm-meta">
+            <span class="badge badge-neutral">{realm.users_count ?? 0} users</span>
+            <span class="expand-icon" class:rotated={expandedId === realm.id}>▸</span>
+          </div>
+        </button>
+
+        {#if expandedId === realm.id}
+          <div class="realm-details">
+            <div class="detail-row">
+              <span class="detail-label">Backend</span>
+              <code>{realm.id}</code>
+              <a href={candidUiUrl(realm.id)} target="_blank" rel="noreferrer" class="link-external">Candid</a>
+              <a href={icDashboardUrl(realm.id)} target="_blank" rel="noreferrer" class="link-external">IC Dashboard</a>
+            </div>
+            {#if realm.url}
+              <div class="detail-row">
+                <span class="detail-label">Frontend</span>
+                <a href={realm.url} target="_blank" rel="noreferrer" class="link-external">{realm.url}</a>
+              </div>
+            {/if}
+            <div class="detail-actions">
+              <a href="/realms/{realm.id}" class="btn btn-sm btn-primary">Full Details</a>
+            </div>
+          </div>
+        {/if}
+      </div>
+    {/each}
+  </div>
+
+  {#if totalPages > 1}
+    <div class="pagination">
+      <button class="btn btn-sm" disabled={currentPage === 0} on:click={() => currentPage--}>Previous</button>
+      <span class="page-info">Page {currentPage + 1} of {totalPages}</span>
+      <button class="btn btn-sm" disabled={currentPage >= totalPages - 1} on:click={() => currentPage++}>Next</button>
+    </div>
+  {/if}
+{/if}
+
+<style>
+  .toolbar { margin-bottom: 1rem; max-width: 400px; }
+  .realm-list { display: flex; flex-direction: column; gap: 0.5rem; }
+  .realm-card { padding: 0; overflow: hidden; }
+  .realm-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    padding: 0.85rem 1.25rem;
+    background: none;
+    border: none;
+    cursor: pointer;
+    text-align: left;
+    color: inherit;
+  }
+  .realm-header:hover { background: var(--surface-2); }
+  .realm-info { display: flex; align-items: center; gap: 0.75rem; }
+  .realm-logo {
+    width: 36px;
+    height: 36px;
+    border-radius: 0.5rem;
+    object-fit: cover;
+  }
+  .realm-logo.placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--surface-2);
+    color: var(--text-faint);
+    font-size: 1.2rem;
+  }
+  .realm-name { font-weight: 600; font-size: 0.95rem; }
+  .realm-id { font-size: 0.75rem; color: var(--text-faint); }
+  .realm-meta { display: flex; align-items: center; gap: 0.75rem; }
+  .expand-icon { transition: transform 0.15s; color: var(--text-faint); }
+  .expand-icon.rotated { transform: rotate(90deg); }
+
+  .realm-details {
+    padding: 0.75rem 1.25rem 1rem;
+    border-top: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+  .detail-row { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; font-size: 0.85rem; }
+  .detail-label { font-weight: 600; font-size: 0.75rem; text-transform: uppercase; color: var(--text-faint); width: 5rem; }
+  .detail-actions { margin-top: 0.5rem; }
+
+  .pagination {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    margin-top: 1.25rem;
+  }
+  .page-info { font-size: 0.85rem; color: var(--text-muted); }
+</style>

--- a/src/platform_dashboard_frontend/src/routes/realms/[realmId]/+page.svelte
+++ b/src/platform_dashboard_frontend/src/routes/realms/[realmId]/+page.svelte
@@ -1,0 +1,234 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { page } from '$app/stores';
+  import { createRealmBackendActor, registryActor } from '$lib/canisters';
+  import { frontendUrl, candidUiUrl, icDashboardUrl, shortId } from '$lib/config';
+  import type { StatusRecord, CanisterInfo, QuarterInfoRecord } from '$lib/types';
+
+  let loading = true;
+  let error = '';
+  let realmName = '';
+  let realmUrl = '';
+  let status: StatusRecord | null = null;
+
+  $: realmId = $page.params.realmId;
+
+  onMount(async () => {
+    try {
+      // Try to get realm info from registry
+      try {
+        const realms = await registryActor.list_realms();
+        const list = realms?.Ok ?? realms;
+        if (Array.isArray(list)) {
+          const found = list.find((r: any) => r.id === realmId);
+          if (found) {
+            realmName = found.name;
+            realmUrl = found.url;
+          }
+        }
+      } catch { /* registry unavailable */ }
+
+      const actor = await createRealmBackendActor(realmId);
+      const raw = await actor.status();
+      status = raw?.Ok ?? raw;
+    } catch (e: any) {
+      error = e.message || 'Failed to load realm details';
+    } finally {
+      loading = false;
+    }
+  });
+
+  function canisterTypeLabel(t: string): string {
+    const labels: Record<string, string> = {
+      'backend': 'Backend',
+      'frontend': 'Frontend',
+      'quarter': 'Quarter',
+      'token': 'Token',
+      'nft': 'NFT',
+      'file_registry': 'File Registry',
+    };
+    return labels[t] || t;
+  }
+</script>
+
+<div class="breadcrumb">
+  <a href="/realms">Realms</a>
+  <span class="sep">/</span>
+  <span>{realmName || shortId(realmId)}</span>
+</div>
+
+<h1 class="page-title">{realmName || 'Realm'}</h1>
+<p class="page-subtitle">
+  Canister ID: <code>{realmId}</code>
+  {#if realmUrl}
+    &middot; <a href={realmUrl} target="_blank" rel="noreferrer" class="link-external">Open Frontend</a>
+  {/if}
+</p>
+
+{#if loading}
+  <div class="empty-state"><span class="spinner"></span> Loading realm status...</div>
+{:else if error}
+  <div class="card" style="border-color: var(--danger); color: var(--danger);">{error}</div>
+{:else if status}
+  <div class="stat-grid">
+    {#if status.version}
+      <div class="stat-card">
+        <div class="stat-value" style="font-size:1.1rem">{status.version}</div>
+        <div class="stat-label">Version</div>
+      </div>
+    {/if}
+    {#if status.users_count != null}
+      <div class="stat-card">
+        <div class="stat-value">{status.users_count}</div>
+        <div class="stat-label">Users</div>
+      </div>
+    {/if}
+    {#if status.objects_count != null}
+      <div class="stat-card">
+        <div class="stat-value">{status.objects_count}</div>
+        <div class="stat-label">Objects</div>
+      </div>
+    {/if}
+    {#if status.extensions && status.extensions.length > 0}
+      <div class="stat-card">
+        <div class="stat-value">{status.extensions.length}</div>
+        <div class="stat-label">Extensions</div>
+      </div>
+    {/if}
+  </div>
+
+  <!-- Core Canisters -->
+  <section class="section">
+    <h2 class="section-title">Canisters</h2>
+    <div class="canister-tree">
+      <!-- The realm backend itself -->
+      <div class="tree-node root">
+        <span class="tree-type badge badge-info">Backend</span>
+        <code class="tree-id">{realmId}</code>
+        <span class="tree-links">
+          <a href={candidUiUrl(realmId)} target="_blank" rel="noreferrer" class="link-external">Candid</a>
+          <a href={icDashboardUrl(realmId)} target="_blank" rel="noreferrer" class="link-external">IC Dashboard</a>
+        </span>
+      </div>
+
+      {#if realmUrl}
+        {@const frontendId = realmUrl.replace('https://', '').replace('.icp0.io', '').replace('.localhost:4943', '')}
+        <div class="tree-node">
+          <span class="tree-type badge badge-success">Frontend</span>
+          <code class="tree-id">{shortId(frontendId)}</code>
+          <span class="tree-links">
+            <a href={realmUrl} target="_blank" rel="noreferrer" class="link-external">Open</a>
+            <a href={icDashboardUrl(frontendId)} target="_blank" rel="noreferrer" class="link-external">IC Dashboard</a>
+          </span>
+        </div>
+      {/if}
+
+      {#if status.canisters}
+        {#each status.canisters as c}
+          <div class="tree-node">
+            <span class="tree-type badge badge-neutral">{canisterTypeLabel(c.canister_type)}</span>
+            {#if c.name}<span class="tree-name">{c.name}</span>{/if}
+            <code class="tree-id">{shortId(c.canister_id)}</code>
+            <span class="tree-links">
+              <a href={candidUiUrl(c.canister_id)} target="_blank" rel="noreferrer" class="link-external">Candid</a>
+              <a href={icDashboardUrl(c.canister_id)} target="_blank" rel="noreferrer" class="link-external">IC Dashboard</a>
+            </span>
+          </div>
+        {/each}
+      {/if}
+    </div>
+  </section>
+
+  <!-- Quarters -->
+  {#if status.quarters && status.quarters.length > 0}
+    <section class="section">
+      <h2 class="section-title">Quarters ({status.quarters.length})</h2>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Canister ID</th>
+              <th>Population</th>
+              <th>Status</th>
+              <th>Links</th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each status.quarters as q}
+              <tr>
+                <td>{q.name}</td>
+                <td><code>{shortId(q.canister_id)}</code></td>
+                <td>{q.population}</td>
+                <td>
+                  <span class="badge"
+                    class:badge-success={q.status === 'active'}
+                    class:badge-warning={q.status === 'initializing'}
+                    class:badge-danger={q.status === 'error'}
+                    class:badge-neutral={!['active','initializing','error'].includes(q.status)}
+                  >{q.status}</span>
+                </td>
+                <td>
+                  <a href={candidUiUrl(q.canister_id)} target="_blank" rel="noreferrer" class="link-external">Candid</a>
+                  <a href={icDashboardUrl(q.canister_id)} target="_blank" rel="noreferrer" class="link-external">IC Dashboard</a>
+                </td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  {/if}
+
+  <!-- Registries -->
+  {#if status.registries && status.registries.length > 0}
+    <section class="section">
+      <h2 class="section-title">Linked Registries</h2>
+      {#each status.registries as r}
+        <div class="tree-node">
+          <span class="tree-type badge badge-neutral">{canisterTypeLabel(r.canister_type)}</span>
+          {#if r.name}<span class="tree-name">{r.name}</span>{/if}
+          <code class="tree-id">{shortId(r.canister_id)}</code>
+          <span class="tree-links">
+            <a href={candidUiUrl(r.canister_id)} target="_blank" rel="noreferrer" class="link-external">Candid</a>
+            <a href={icDashboardUrl(r.canister_id)} target="_blank" rel="noreferrer" class="link-external">IC Dashboard</a>
+          </span>
+        </div>
+      {/each}
+    </section>
+  {/if}
+{/if}
+
+<style>
+  .breadcrumb {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    margin-bottom: 0.75rem;
+  }
+  .breadcrumb a { color: var(--primary); text-decoration: none; }
+  .breadcrumb a:hover { text-decoration: underline; }
+  .sep { margin: 0 0.4rem; color: var(--text-faint); }
+
+  .section { margin-top: 2rem; }
+  .section-title { font-size: 1.1rem; margin: 0 0 0.75rem; font-weight: 600; }
+
+  .canister-tree { display: flex; flex-direction: column; gap: 0.4rem; }
+  .tree-node {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+    padding: 0.5rem 0.75rem;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 0.5rem;
+  }
+  .tree-node.root { border-color: var(--primary); border-width: 2px; }
+  .tree-type { flex-shrink: 0; }
+  .tree-name { font-size: 0.85rem; font-weight: 500; }
+  .tree-id { font-size: 0.78rem; color: var(--text-muted); }
+  .tree-links { display: flex; gap: 0.5rem; margin-left: auto; }
+
+  .table-wrap { overflow-x: auto; border: 1px solid var(--border); border-radius: 0.5rem; }
+  .table-wrap table { margin: 0; }
+</style>

--- a/src/platform_dashboard_frontend/src/vite-env.d.ts
+++ b/src/platform_dashboard_frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/src/platform_dashboard_frontend/static/.ic-assets.json5
+++ b/src/platform_dashboard_frontend/static/.ic-assets.json5
@@ -1,0 +1,27 @@
+[
+  {
+    "match": ".well-known",
+    "ignore": false
+  },
+  {
+    "match": ".well-known/*",
+    "ignore": false,
+    "headers": {
+      "Content-Type": "text/plain"
+    }
+  },
+  {
+    "match": "**/*.svg",
+    "headers": {
+      "Content-Type": "image/svg+xml",
+      "Cache-Control": "public, max-age=31536000, immutable"
+    }
+  },
+  {
+    "match": "**/*",
+    "security_policy": "standard",
+    "headers": {
+      "Content-Security-Policy": "default-src 'self';script-src 'self' 'unsafe-eval' 'unsafe-inline';connect-src 'self' http://localhost:* http://*.localhost:* https://icp0.io https://*.icp0.io https://icp-api.io https://*.ic0.app;img-src 'self' data: http://*.localhost:* https://*.icp0.io https://*.ic0.app;style-src * 'unsafe-inline';style-src-elem * 'unsafe-inline';font-src *;object-src 'none';base-uri 'self';frame-ancestors 'none';form-action 'self';upgrade-insecure-requests;"
+    }
+  }
+]

--- a/src/platform_dashboard_frontend/static/favicon.svg
+++ b/src/platform_dashboard_frontend/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#2563EB"/>
+  <path d="M8 10h16v2H8zm0 5h12v2H8zm0 5h14v2H8z" fill="#fff"/>
+</svg>

--- a/src/platform_dashboard_frontend/svelte.config.js
+++ b/src/platform_dashboard_frontend/svelte.config.js
@@ -1,0 +1,18 @@
+import adapter from '@sveltejs/adapter-static';
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+  preprocess: vitePreprocess(),
+  kit: {
+    adapter: adapter({
+      pages: 'dist',
+      assets: 'dist',
+      fallback: 'index.html',
+      precompress: false,
+      strict: true,
+    }),
+  },
+};
+
+export default config;

--- a/src/platform_dashboard_frontend/tsconfig.json
+++ b/src/platform_dashboard_frontend/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./.svelte-kit/tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": false,
+    "moduleResolution": "bundler"
+  }
+}

--- a/src/platform_dashboard_frontend/vite.config.js
+++ b/src/platform_dashboard_frontend/vite.config.js
@@ -1,0 +1,36 @@
+import { fileURLToPath, URL } from 'url';
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
+import environment from 'vite-plugin-environment';
+import dotenv from 'dotenv';
+
+dotenv.config({ path: '../../.env' });
+
+export default defineConfig({
+  build: { emptyOutDir: true },
+  optimizeDeps: {
+    esbuildOptions: { define: { global: 'globalThis' } },
+  },
+  server: {
+    proxy: {
+      '/api': { target: 'http://127.0.0.1:4943', changeOrigin: true },
+    },
+  },
+  plugins: [
+    sveltekit(),
+    environment('all', { prefix: 'CANISTER_' }),
+    environment('all', { prefix: 'DFX_' }),
+  ],
+  resolve: {
+    alias: [
+      {
+        find: 'declarations',
+        replacement: fileURLToPath(new URL('../declarations', import.meta.url)),
+      },
+      { find: '@icp-sdk/core/agent', replacement: '@dfinity/agent' },
+      { find: '@icp-sdk/core/principal', replacement: '@dfinity/principal' },
+      { find: '@icp-sdk/core/candid', replacement: '@dfinity/candid' },
+    ],
+    dedupe: ['@dfinity/agent'],
+  },
+});


### PR DESCRIPTION
## Summary

- Adds a new **platform_dashboard_frontend** SvelteKit 4 asset canister that provides a unified on-chain directory of all platform canisters
- Replaces the off-chain `realms-management-service` for canister directory and installer monitoring (CycleOps continues handling cycles/memory monitoring)
- CI automatically builds and deploys this canister alongside `realm_registry_frontend` on every stage-2 run

### Pages

| Route | Purpose |
|-------|---------|
| `/` | Dashboard overview: realm count, marketplace stats, file registry storage, installer health |
| `/platform` | Card grid for each subsystem (Registry, Installer, Marketplace, File Registry) with status, version, Candid/frontend links |
| `/realms` | Searchable, paginated list of all registered realms with expandable canister details |
| `/realms/[id]` | Full canister tree for a realm: backend, frontend, quarters, tokens, NFTs, linked registries |
| `/installer` | Installer health/version, deployments table with status badges |
| `/installer/[id]` | Step-by-step deployment progress with logs |

### Changes

- `src/platform_dashboard_frontend/` -- full SvelteKit app (auth, lazy actor proxies for 5 backend canisters, config helpers, 6 route pages, dark/light theme)
- `dfx.json` -- added `platform_dashboard_frontend` assets canister entry
- `package.json` -- added workspace entry
- `scripts/ci_install_mundus.py` -- added `_deploy_dashboard_frontend()` called after `_deploy_registry_frontend()` in stage 2
- 14 unit tests (vitest) for config helpers and type contracts

### Deployment Note

The canister needs to be **created** on staging and demo before CI can deploy it:

```bash
dfx canister create platform_dashboard_frontend --network staging --subnet-type application
dfx canister create platform_dashboard_frontend --network demo --subnet-type application
```

The deployer identity needs sufficient cycles (~0.1 TC per canister creation). Once created, add the canister IDs to `canister_ids.json` and CI will deploy automatically.

## Test plan

- [x] `npm run build --workspace=platform_dashboard_frontend` succeeds
- [x] `vitest run` -- 14/14 tests pass
- [ ] Create canisters on staging/demo (requires cycles top-up)
- [ ] Verify live deployment at `https://<canister_id>.icp0.io/`
- [ ] Verify all pages load and query backend canisters correctly


Made with [Cursor](https://cursor.com)