### PR TITLE
feat(ci): platform dashboard deploy + CycleOps auto-registration

### DIFF
--- a/.github/workflows/_deploy-dashboard.yml
+++ b/.github/workflows/_deploy-dashboard.yml
@@ -1,0 +1,117 @@
+# _deploy-dashboard.yml — reusable workflow.
+#
+# Builds the platform_dashboard_frontend SvelteKit app and deploys it as
+# an IC asset canister on the target network.
+#
+# The dashboard is a standalone frontend — no backend canister to build.
+# It queries existing canisters (registry, installer, marketplace,
+# file_registry) directly from the browser via @dfinity/agent.
+
+name: _deploy-dashboard
+
+on:
+  workflow_call:
+    inputs:
+      network:
+        description: "Target network: staging | demo | ic"
+        required: true
+        type: string
+    secrets:
+      IC_IDENTITY_PEM:
+        required: true
+
+env:
+  NODE_VERSION: "20"
+  DFX_VERSION: "0.31.0"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install dfx ${{ env.DFX_VERSION }}
+        run: |
+          DFXVM_INIT_YES=1 sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)"
+          echo "$HOME/.local/share/dfx/bin" >> "$GITHUB_PATH"
+
+      - name: Configure dfx identity
+        env:
+          IC_IDENTITY_PEM: ${{ secrets.IC_IDENTITY_PEM }}
+        run: |
+          if [ -z "$IC_IDENTITY_PEM" ]; then
+            echo "::error::IC_IDENTITY_PEM secret is not set." >&2
+            exit 1
+          fi
+          printf '%s' "$IC_IDENTITY_PEM" > /tmp/identity.pem
+          chmod 600 /tmp/identity.pem
+          dfx identity import ci /tmp/identity.pem --storage-mode=plaintext --force
+          dfx identity use ci
+          rm -f /tmp/identity.pem
+          echo "DFX_WARNING=-mainnet_plaintext_identity" >> "$GITHUB_ENV"
+
+      - name: Generate canister environment
+        run: |
+          dfx canister id platform_dashboard_frontend --network ${{ inputs.network }} 2>/dev/null || true
+
+      - name: Install npm workspace dependencies
+        run: npm ci
+
+      - name: Build platform_dashboard_frontend
+        run: npm run build
+        working-directory: src/platform_dashboard_frontend
+
+      - name: Deploy platform_dashboard_frontend
+        run: |
+          dfx deploy platform_dashboard_frontend \
+            --network ${{ inputs.network }} \
+            --yes
+          CANISTER_ID=$(dfx canister id platform_dashboard_frontend --network ${{ inputs.network }})
+          echo "DASHBOARD_CANISTER_ID=$CANISTER_ID" >> "$GITHUB_ENV"
+          echo "platform_dashboard_frontend deployed: https://${CANISTER_ID}.icp0.io"
+
+      - name: Register with CycleOps
+        if: success()
+        env:
+          CYCLEOPS: qc4nb-ciaaa-aaaap-aawqa-cai
+          TEAM_PRINCIPAL: xee7m-jddpf-rwyzl-pobzx-izlbn-vhsbt-ublzn-lf4vo-kbvz2-buwfk-xh6
+        run: |
+          CANISTER_ID="$DASHBOARD_CANISTER_ID"
+          NETWORK="${{ inputs.network }}"
+          DISPLAY_NAME="${NETWORK}-platform_dashboard_frontend"
+
+          THRESHOLD=2000000000000
+          TOPUP=4000000000000
+          TOPUP_RULE="opt record { threshold = $THRESHOLD : nat; method = variant { to_balance = $TOPUP : nat } }"
+          TEAM='opt principal "'"$TEAM_PRINCIPAL"'"'
+
+          echo "Registering $DISPLAY_NAME ($CANISTER_ID) with CycleOps..."
+
+          add_result=$(dfx canister call "$CYCLEOPS" addCanister "(record {
+            asTeamPrincipal = $TEAM;
+            canisterId = principal \"$CANISTER_ID\";
+            name = opt \"$DISPLAY_NAME\";
+            topupRule = $TOPUP_RULE;
+          })" --network ic 2>&1) || true
+
+          if echo "$add_result" | grep -q "ok\|notVerified\|already_added"; then
+            verify_result=$(dfx canister call "$CYCLEOPS" verifyBlackholeAddedAsControllerVersioned "(record {
+              asTeamPrincipal = $TEAM;
+              canisterId = principal \"$CANISTER_ID\";
+              blackholeVersion = 3 : nat;
+            })" --network ic 2>&1) || true
+
+            if echo "$verify_result" | grep -q "verified\|ok"; then
+              echo "CycleOps registration verified"
+            else
+              echo "::warning::CycleOps blackhole verification pending — add cpbhu-5iaaa-aaaad-aalta-cai as controller"
+            fi
+          else
+            echo "::warning::CycleOps addCanister: $add_result"
+          fi

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -101,3 +101,11 @@ jobs:
     with:
       network: staging
       descriptor: deployments/staging-mundus-layered.yml
+
+  deploy-dashboard-staging:
+    needs: layered-e2e-local
+    uses: ./.github/workflows/_deploy-dashboard.yml
+    with:
+      network: staging
+    secrets:
+      IC_IDENTITY_PEM: ${{ secrets.IC_IDENTITY_PEM }}

--- a/.github/workflows/fast-deploy-staging.yml
+++ b/.github/workflows/fast-deploy-staging.yml
@@ -159,18 +159,36 @@ jobs:
           echo "→ python3 scripts/ci_install_mundus.py $*"
           python3 scripts/ci_install_mundus.py "$@"
 
+      - name: Build and deploy platform dashboard
+        run: |
+          NETWORK=$(python3 -c "import yaml; print(yaml.safe_load(open('${{ inputs.descriptor }}'))['network'])")
+          echo "Building platform_dashboard_frontend for $NETWORK..."
+          cd src/platform_dashboard_frontend && npm run build && cd ../..
+          dfx deploy platform_dashboard_frontend --network "$NETWORK" --yes
+          DASH_ID=$(dfx canister id platform_dashboard_frontend --network "$NETWORK")
+          echo "Dashboard deployed: https://${DASH_ID}.icp0.io"
+
       - name: Print frontend URLs
         if: success()
         run: |
           python3 - <<'PY'
-          import os, yaml
+          import os, yaml, subprocess
           desc = yaml.safe_load(open(os.environ["DESC"]))
+          network = desc["network"]
           print()
           print("✅ Fast deploy complete. Live frontends:")
           for m in desc.get("mundus", []):
               fe = m.get("frontend_canister_id")
               if fe:
                   print(f"   • {m.get('display_name') or m['name']:14s} → https://{fe}.icp0.io/")
+          try:
+              dash_id = subprocess.check_output(
+                  ["dfx", "canister", "id", "platform_dashboard_frontend", "--network", network],
+                  text=True
+              ).strip()
+              print(f"   • {'Dashboard':14s} → https://{dash_id}.icp0.io/")
+          except Exception:
+              pass
           PY
         env:
           DESC: ${{ inputs.descriptor }}

--- a/.github/workflows/layered-deploy-demo.yml
+++ b/.github/workflows/layered-deploy-demo.yml
@@ -67,3 +67,10 @@ jobs:
     with:
       network: demo
       descriptor: deployments/demo-mundus-layered.yml
+
+  deploy-dashboard:
+    uses: ./.github/workflows/_deploy-dashboard.yml
+    with:
+      network: demo
+    secrets:
+      IC_IDENTITY_PEM: ${{ secrets.IC_IDENTITY_PEM }}

--- a/.github/workflows/layered-deploy-dominion.yml
+++ b/.github/workflows/layered-deploy-dominion.yml
@@ -68,3 +68,10 @@ jobs:
     with:
       network: staging
       descriptor: deployments/staging-mundus-layered.yml
+
+  deploy-dashboard:
+    uses: ./.github/workflows/_deploy-dashboard.yml
+    with:
+      network: staging
+    secrets:
+      IC_IDENTITY_PEM: ${{ secrets.IC_IDENTITY_PEM }}

--- a/deployments/demo-mundus-layered.yml
+++ b/deployments/demo-mundus-layered.yml
@@ -14,8 +14,6 @@ infrastructure_overrides:
     canister_id: vi64l-3aaaa-aaaae-qj4va-cai
   realm_installer:
     canister_id: 2s4td-daaaa-aaaao-bazmq-cai
-  realm_installer:
-    canister_id: 2s4td-daaaa-aaaao-bazmq-cai
 
 artifacts:
   base_wasm:

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -91,6 +91,7 @@ export default defineConfig({
         {
           text: 'Architecture',
           items: [
+            { text: 'Canister Diagram', link: '/reference/TECHNICAL_INTRO#canister-diagram' },
             { text: 'Frontend Architecture', link: '/reference/FRONTEND_ARCHITECTURE' },
             { text: 'Extension Architecture', link: '/reference/EXTENSION_ARCHITECTURE' },
             { text: 'Method Override System', link: '/reference/METHOD_OVERRIDE_SYSTEM' }

--- a/docs/reference/TECHNICAL_INTRO.md
+++ b/docs/reference/TECHNICAL_INTRO.md
@@ -13,15 +13,98 @@ Realms is a **full-stack governance platform** built on the Internet Computer Pr
 - **Authentication**: Internet Identity
 - **Blockchain**: Internet Computer Protocol
 
+### Canister Diagram
+
+```mermaid
+flowchart LR
+    subgraph realms["Each Realm (× N)"]
+        direction TB
+        FE["frontend\n(asset canister)"]
+        BE["backend\n(core logic)"]
+        Q["quarters\n(optional backend\ninstances)"]
+        TOK["token\n(optional, ICRC-1)"]
+        NFT["land NFT\n(optional, ICRC-7)"]
+        FE --> BE
+        BE --- Q
+        BE -.-> TOK
+        BE -.-> NFT
+    end
+
+    subgraph registry["Realm Registry"]
+        direction TB
+        RRF["registry\nfrontend"]
+        RRB["registry\nbackend\n(directory +\ncredits)"]
+        RRF --> RRB
+    end
+
+    subgraph infra["Project Infrastructure"]
+        direction TB
+        FR["file_registry\n(WASM + packages)"]
+        RI["realm_installer\n(deploy orchestrator)"]
+        MP["marketplace\n(extension catalog)"]
+        FRF["file_registry FE"]
+        MF["marketplace FE"]
+        FRF --> FR
+        MF --> MP
+    end
+
+    subgraph external["External"]
+        direction TB
+        II["Internet\nIdentity"]
+        MGMT["IC Mgmt\nCanister"]
+        CKBTC["ckBTC\nLedger"]
+        BILLING["Billing\nService"]
+    end
+
+    %% Realm ↔ Registry
+    BE -->|"register"| RRB
+    RRF -.->|"status"| BE
+
+    %% Installer flow
+    RI -->|"install WASM +\nconfig"| BE
+    RI -->|"stream chunks"| FR
+    RI -->|"chunked install"| MGMT
+    RRF -->|"deploy_realm"| RI
+    RI -->|"push assets"| FE
+
+    %% File registry usage
+    BE -->|"pull files"| FR
+    MF -.->|"upload"| FR
+    RRF -.->|"publish"| FR
+
+    %% External
+    BE -->|"vetKD"| MGMT
+    BE -->|"ICRC-1"| CKBTC
+    FE -.->|"auth"| II
+    RRF -.->|"auth"| II
+    MF -.->|"auth"| II
+    BILLING -.->|"credits"| RRB
+```
+
+The system is organized into four logical layers:
+
+- **Realms** — each realm is a self-contained unit with its own frontend + backend canister pair, optional quarters (additional backend instances for horizontal scaling), and optional per-realm tokens (fungible ICRC-1 and land NFT ICRC-7).
+- **Realm Registry** — central directory where all realms register themselves, plus a credit/billing ledger. The registry frontend also drives realm creation by coordinating with the installer.
+- **Project Infrastructure** — shared services: `file_registry` (on-chain blob store for WASM/manifests/packages), `realm_installer` (timer-driven orchestrator for chunked WASM deploys), and `marketplace` (extension/codex catalog with listings and licenses).
+- **External** — platform-level canisters and services not owned by the project: Internet Identity (auth), IC management canister (vetKD + chunked code install), ckBTC ledger, and an off-chain billing service.
+
 ### Core Components
 
-**Realm Backend Canister** - Python-based business logic, entity management, task execution
+**Realm Backend Canister** — Python-based business logic: entities, governance, finance, zones, extensions, vetKD crypto, and task automation. Each realm deploys its own instance.
 
-**Realm Frontend Canister** - SvelteKit app served directly from blockchain
+**Realm Frontend Canister** — SvelteKit app served directly from blockchain. Connects to its realm backend and optionally to the file registry for extension bundles.
 
-**Registry Canister** - Global realm discovery and registration
+**Quarters** — Optional additional `realm_backend` instances that partition a realm for horizontal scaling. The frontend routes to the appropriate quarter by canister ID.
 
-**Extension System** - Modular plugins for custom functionality
+**Registry Backend** — Global realm discovery, registration, search, and credit ledger for billing. Realm backends self-register here on startup.
+
+**File Registry** — On-chain file store for WASM blobs, extension/codex packages, and manifests. Serves files via both Candid (inter-canister) and HTTP.
+
+**Realm Installer** — Orchestrates multi-step realm deployments: streams WASM chunks from the file registry, installs code via the IC management canister, configures the target backend, and pushes assets to the frontend canister.
+
+**Marketplace** — Catalog for extensions, codices, and assistants with listings, licenses, and verification. Frontends bridge it to the file registry for uploads.
+
+**Extension System** — Modular plugins for custom functionality with backend + frontend components.
 
 ## Key Features
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -11,6 +11,7 @@ Complete reference documentation for the Realms GOS platform.
 - **[Frontend Architecture](./FRONTEND_ARCHITECTURE)** - UI structure and patterns
 
 ### Architecture
+- **[Technical Overview & Canister Diagram](./TECHNICAL_INTRO)** - System architecture and canister relationships
 - **[Extension Architecture](./EXTENSION_ARCHITECTURE)** - Build custom extensions
 - **[Method Override System](./METHOD_OVERRIDE_SYSTEM)** - Extension method injection
 - **[Frontend Architecture](./FRONTEND_ARCHITECTURE)** - Svelte components and routing

--- a/scripts/ci_install_mundus.py
+++ b/scripts/ci_install_mundus.py
@@ -151,6 +151,99 @@ def _add_controller(canister: str, controller: str, network: str) -> None:
 
 
 # ---------------------------------------------------------------------------
+# CycleOps monitoring — register newly created canisters
+# ---------------------------------------------------------------------------
+
+CYCLEOPS_CANISTER = "qc4nb-ciaaa-aaaap-aawqa-cai"
+CYCLEOPS_BLACKHOLE_V3 = "cpbhu-5iaaa-aaaad-aalta-cai"
+_CYCLEOPS_TEAM = os.environ.get(
+    "CYCLEOPS_TEAM_PRINCIPAL",
+    "xee7m-jddpf-rwyzl-pobzx-izlbn-vhsbt-ublzn-lf4vo-kbvz2-buwfk-xh6",
+)
+
+_CYCLEOPS_THRESHOLD = 2_000_000_000_000  # 2 TC
+_CYCLEOPS_TOPUP = 4_000_000_000_000      # 4 TC
+
+
+def _cycleops_display_name(
+    canister_name: str, network: str, *, suffix: Optional[str] = None
+) -> str:
+    """Build a CycleOps display name following existing nomenclature.
+
+    Convention: ``{network}-{name}[_{suffix}]``
+
+    If *canister_name* already carries a ``_backend`` or ``_frontend``
+    suffix (e.g. ``file_registry_frontend``) or *suffix* is ``None``,
+    nothing is appended.  Otherwise *suffix* (e.g. ``"backend"`` or
+    ``"frontend"``) is appended with an underscore.
+
+    Examples:
+      staging-dominion_backend   — suffix="backend"
+      demo-file_registry         — suffix=None (infra, no role suffix)
+      staging-file_registry_frontend — name already has _frontend
+    """
+    if (
+        suffix
+        and not canister_name.endswith("_frontend")
+        and not canister_name.endswith("_backend")
+    ):
+        return f"{network}-{canister_name}_{suffix}"
+    return f"{network}-{canister_name}"
+
+
+def _register_canister_with_cycleops(
+    canister_id: str,
+    display_name: str,
+    network: str,
+) -> None:
+    """Best-effort: add a canister to the CycleOps team with standard top-up rules.
+
+    Failure to register doesn't block the deploy.  Requires the V3
+    blackhole to be a controller (added separately by ``_add_controller``).
+    """
+    if not canister_id:
+        return
+    team_arg = f'opt principal "{_CYCLEOPS_TEAM}"'
+    topup_rule = (
+        f"opt record {{ threshold = {_CYCLEOPS_THRESHOLD} : nat; "
+        f"method = variant {{ to_balance = {_CYCLEOPS_TOPUP} : nat }} }}"
+    )
+    try:
+        result = subprocess.run(
+            [
+                "dfx", "canister", "call", "--network", "ic",
+                CYCLEOPS_CANISTER, "addCanister",
+                f'(record {{ '
+                f'asTeamPrincipal = {team_arg}; '
+                f'canisterId = principal "{canister_id}"; '
+                f'name = opt "{display_name}"; '
+                f'topupRule = {topup_rule}; '
+                f'}})',
+            ],
+            capture_output=True, text=True, timeout=60,
+        )
+        if "ok" in (result.stdout or "") or "already" in (result.stdout or ""):
+            subprocess.run(
+                [
+                    "dfx", "canister", "call", "--network", "ic",
+                    CYCLEOPS_CANISTER, "verifyBlackholeAddedAsControllerVersioned",
+                    f'(record {{ '
+                    f'asTeamPrincipal = {team_arg}; '
+                    f'canisterId = principal "{canister_id}"; '
+                    f'blackholeVersion = 3 : nat; '
+                    f'}})',
+                ],
+                capture_output=True, text=True, timeout=60,
+            )
+            print(f"   📊 registered {display_name} ({canister_id}) with CycleOps")
+        else:
+            print(f"   ⚠ CycleOps addCanister for {display_name}: "
+                  f"{(result.stdout or result.stderr or '')[:200]}")
+    except Exception as e:
+        print(f"   ⚠ CycleOps registration failed for {display_name}: {e}")
+
+
+# ---------------------------------------------------------------------------
 # Stage 0 — bootstrap infrastructure
 # ---------------------------------------------------------------------------
 
@@ -173,10 +266,19 @@ def stage0_bootstrap(descriptor: Dict[str, Any]) -> Dict[str, str]:
             continue
 
         existing = _canister_id(name, network)
+        newly_created = False
         if not existing:
             _dfx("canister", "create", name, network=network)
+            newly_created = True
         _dfx("deploy", name, "--yes", network=network, check=False)
-        ids[name] = _canister_id(name, network) or ""
+        cid = _canister_id(name, network) or ""
+        ids[name] = cid
+
+        if cid:
+            _add_controller(cid, CYCLEOPS_BLACKHOLE_V3, network)
+        if newly_created and cid:
+            display = _cycleops_display_name(name, network)
+            _register_canister_with_cycleops(cid, display, network)
 
     print(f"   ✅ infrastructure: {ids}")
     return ids
@@ -731,9 +833,11 @@ def _kickoff_deploy(
     """
     name = member["name"]
     canister_id = member.get("canister_id") or _canister_id(name, network)
+    newly_created = False
     if not canister_id:
         _dfx("canister", "create", name, network=network)
         canister_id = _canister_id(name, network)
+        newly_created = True
 
     member_mode = (member.get("install_mode") or default_mode).strip()
     wasm_spec = _wasm_spec_for_member(member, base_version)
@@ -746,6 +850,20 @@ def _kickoff_deploy(
     # install_codex_from_registry are accepted by realm_backend's
     # controller-bypass auth path (core/access.py).
     _add_controller(canister_id, realm_installer, network)
+
+    _add_controller(canister_id, CYCLEOPS_BLACKHOLE_V3, network)
+    if newly_created and canister_id:
+        display = _cycleops_display_name(name, network, suffix="backend")
+        _register_canister_with_cycleops(canister_id, display, network)
+
+    frontend_id = member.get("frontend_canister_id")
+    if frontend_id:
+        _add_controller(frontend_id, CYCLEOPS_BLACKHOLE_V3, network)
+        if newly_created:
+            fe_display = _cycleops_display_name(
+                name, network, suffix="frontend",
+            )
+            _register_canister_with_cycleops(frontend_id, fe_display, network)
 
     manifest = _build_deploy_manifest(
         member,

--- a/scripts/update_cycleops_thresholds.sh
+++ b/scripts/update_cycleops_thresholds.sh
@@ -63,10 +63,8 @@ declare -A ALL_CANISTERS=(
   ["4uolp-aqaaa-aaaaf-qdojq-cai"]="nft_realm2"
   ["4bj2c-byaaa-aaaaf-qdoka-cai"]="nft_realm3"
   # --- Platform Dashboard ---
-  # Canister IDs are assigned on first deploy; update these after
-  # running: dfx canister id platform_dashboard_frontend --network <staging|demo>
-  # ["<staging-canister-id>"]="staging-platform_dashboard_frontend"
-  # ["<demo-canister-id>"]="demo-platform_dashboard_frontend"
+  ["dpgu3-wqaaa-aaaau-agqoa-cai"]="staging-platform_dashboard_frontend"
+  ["rxtxq-kyaaa-aaaac-qgora-cai"]="demo-platform_dashboard_frontend"
 )
 
 TOPUP_RULE="opt record { threshold = $THRESHOLD : nat; method = variant { to_balance = $TOPUP : nat } }"


### PR DESCRIPTION
## Summary

**Platform dashboard CI/CD** (commit 1):
- New reusable `_deploy-dashboard.yml` workflow that builds the SvelteKit dashboard and deploys it as an IC asset canister
- Wired into all deployment workflows: `ci-main.yml`, `layered-deploy-demo.yml`, `layered-deploy-dominion.yml`, and `fast-deploy-staging.yml`

**CycleOps auto-registration** (commit 2):
- Added 4 missing infrastructure canisters to `update_cycleops_thresholds.sh` (staging file_registry, staging file_registry_frontend, staging realm_installer, demo realm_installer)
- New auto-registration in `ci_install_mundus.py`: newly created canisters (stage 0 infra + stage 2 realm members) are automatically added to the CycleOps team with 2 TC threshold / 4 TC top-up rules, V3 blackhole added as controller
- Fixed duplicate `realm_installer` key in `demo-mundus-layered.yml`
- Added canister architecture diagram to `TECHNICAL_INTRO.md`

All 30 canisters verified ✅ in CycleOps.

## Test plan

- [ ] Verify staging dashboard loads at https://dpgu3-wqaaa-aaaau-agqoa-cai.icp0.io/
- [ ] Verify demo dashboard loads at https://rxtxq-kyaaa-aaaac-qgora-cai.icp0.io/
- [ ] Trigger staging deploy and confirm CycleOps auto-registration logic runs
- [ ] Check CycleOps dashboard shows all 30 canisters with correct thresholds