### PR TITLE
Use ic-python-db 0.9.0 reverse indexes, remove instances() workarounds

### DIFF
--- a/cli/realms/cli/requirements.txt
+++ b/cli/realms/cli/requirements.txt
@@ -4,7 +4,7 @@ ic-basilisk==0.13.1
     #   ic-basilisk-toolkit
 ic-basilisk-toolkit==0.3.0
     # via -r realms/cli/realms/cli/requirements.in
-ic-python-db==0.8.2
+ic-python-db==0.9.0
     # via ic-basilisk-toolkit
 ic-python-logging==0.3.4
     # via ic-basilisk-toolkit

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ ic-basilisk==0.13.1
     # via ic-basilisk-toolkit
 ic-basilisk-toolkit==0.3.0
     # via -r realms/requirements.in
-ic-python-db==0.8.2
+ic-python-db==0.9.0
     # via ic-basilisk-toolkit
 ic-python-logging==0.3.4
     # via ic-basilisk-toolkit

--- a/src/marketplace_backend/requirements.txt
+++ b/src/marketplace_backend/requirements.txt
@@ -4,7 +4,7 @@ ic-basilisk==0.13.1
     #   ic-basilisk-toolkit
 ic-basilisk-toolkit==0.3.0
     # via -r realms/src/marketplace_backend/requirements.in
-ic-python-db==0.8.2
+ic-python-db==0.9.0
     # via ic-basilisk-toolkit
 ic-python-logging==0.3.4
     # via ic-basilisk-toolkit

--- a/src/realm_backend/main.py
+++ b/src/realm_backend/main.py
@@ -2138,17 +2138,12 @@ def initialize() -> void:
     # After an upgrade, any in-progress tasks lost their timers, so reset
     # non-completed tasks back to pending before scheduling.
     try:
-        # Eagerly load related entities so ManyToOne descriptors resolve and
-        # populate bidirectional _relations on Task (steps, schedules) before
-        # any property modifications trigger _save() which would otherwise
-        # serialize entities with empty _relations, losing relationship data.
-        list(Task.instances())
-        list(Call.instances())
-        list(TaskStep.instances())
-        list(TaskSchedule.instances())
+        # Relationships resolve via persisted reverse indexes (ic-python-db >= 0.9)
+        # — no need to eagerly load child entity types.
+        all_tasks = Task.load_some(1, Task.max_id()) if Task.max_id() > 0 else []
 
         manager = TaskManager()
-        for t in Task.instances():
+        for t in all_tasks:
             if t.status and t.status != "completed":
                 t.status = "pending"
                 t.step_to_execute = 0
@@ -2223,17 +2218,13 @@ def start_task_manager() -> text:
     __shell__ do NOT survive IC call boundaries.
     """
     try:
-        # Eagerly load related entities so ManyToOne descriptors resolve and
-        # populate bidirectional _relations on Task (steps, schedules) before
-        # any property modifications trigger _save().
-        list(Task.instances())
-        list(Call.instances())
-        list(TaskStep.instances())
-        list(TaskSchedule.instances())
+        # Relationships resolve via persisted reverse indexes (ic-python-db >= 0.9)
+        # — no need to eagerly load child entity types.
+        all_tasks = Task.load_some(1, Task.max_id()) if Task.max_id() > 0 else []
 
         manager = TaskManager()
         count = 0
-        for t in Task.instances():
+        for t in all_tasks:
             if t.status and t.status != "completed":
                 t.status = "pending"
                 t.step_to_execute = 0

--- a/src/realm_installer/requirements.txt
+++ b/src/realm_installer/requirements.txt
@@ -4,7 +4,7 @@ ic-basilisk==0.13.1
     #   ic-basilisk-toolkit
 ic-basilisk-toolkit==0.3.0
     # via -r realms/src/realm_installer/requirements.in
-ic-python-db==0.8.2
+ic-python-db==0.9.0
     # via ic-basilisk-toolkit
 ic-python-logging==0.3.4
     # via ic-basilisk-toolkit

--- a/src/realm_registry_backend/requirements.txt
+++ b/src/realm_registry_backend/requirements.txt
@@ -4,7 +4,7 @@ ic-basilisk==0.13.1
     #   ic-basilisk-toolkit
 ic-basilisk-toolkit==0.3.0
     # via -r realms/src/realm_registry_backend/requirements.in
-ic-python-db==0.8.2
+ic-python-db==0.9.0
     # via ic-basilisk-toolkit
 ic-python-logging==0.3.4
     # via ic-basilisk-toolkit


### PR DESCRIPTION
## Summary
- Bumps `ic-python-db` to 0.9.0 across all requirements files (realm_backend, marketplace, vault, installer, registry, CLI)
- Removes expensive `list(Task/Call/TaskStep/TaskSchedule.instances())` calls from `post_upgrade()` and `_restart_task_manager()` hooks in `main.py`
- Updates `extensions` submodule with the same fix for the demo_simulator entry point

## Context
With ic-python-db 0.9.0, relationship properties (`.steps`, `.schedules`) resolve via persisted reverse indexes in stable storage. The old pattern of eagerly loading all child entity types just to populate the in-memory `_relations` dict is no longer needed. This was the root cause of the demo simulator exceeding IC instruction limits as entity counts grew.

## Test plan
- [ ] Deploy realm canister and verify post_upgrade succeeds
- [ ] Run demo_simulator and confirm entity counts continue growing without stalling
- [ ] Verify task scheduling works across canister upgrades


Made with [Cursor](https://cursor.com)