### PR TITLE
fix(publish): incremental finalize for large chunked uploads

### DIFF
--- a/cli/realms/cli/commands/extension.py
+++ b/cli/realms/cli/commands/extension.py
@@ -1204,24 +1204,42 @@ def _upload_one_file(
                 )
                 return "failed"
 
-    finalize_payload = json.dumps({"namespace": namespace, "path": registry_path})
-    candid_arg = '("' + finalize_payload.replace("\\", "\\\\").replace('"', '\\"') + '")'
-    raw = _dfx_call(
-        registry,
-        "finalize_chunked_file",
-        candid_arg,
-        network,
-        identity,
-        timeout=600,
-    )
-    try:
-        res = json.loads(raw)
-    except json.JSONDecodeError:
-        res = {"raw": raw}
-    if isinstance(res, dict) and (res.get("ok") is True or res.get("success") is True):
-        console.print(f"  [green]✓[/green] {namespace}/{registry_path} ({size:,} bytes, chunked)")
-        return "uploaded"
-    console.print(f"  [red]✗[/red] finalize failed for {registry_path}: {res}")
+    # Finalize incrementally: the single-shot finalize_chunked_file reassembles
+    # + hashes the whole file in one message, which blows the 40B-instruction
+    # budget for multi-MB files (e.g. the 1.8 MB base WASM). finalize_chunked_file_step
+    # concatenates a small batch of chunks per call and skips on-chain hashing,
+    # so we pass the locally-computed sha256 once and poll until done.
+    expected_sha256 = _local_file_sha256(local_path)
+    # ~800 KiB of byte-copy work per step keeps each message well under budget.
+    batch_size = max(1, (800 * 1024) // _PUBLISH_CHUNK_SIZE_BYTES)
+    max_steps = total_chunks + 5
+    for _step in range(max_steps):
+        step_payload = json.dumps({
+            "namespace": namespace,
+            "path": registry_path,
+            "expected_sha256": expected_sha256,
+            "batch_size": batch_size,
+        })
+        candid_arg = '("' + step_payload.replace("\\", "\\\\").replace('"', '\\"') + '")'
+        raw = _dfx_call(
+            registry,
+            "finalize_chunked_file_step",
+            candid_arg,
+            network,
+            identity,
+            timeout=600,
+        )
+        try:
+            res = json.loads(raw)
+        except json.JSONDecodeError:
+            res = {"raw": raw}
+        if not (isinstance(res, dict) and res.get("ok") is True):
+            console.print(f"  [red]✗[/red] finalize failed for {registry_path}: {res}")
+            return "failed"
+        if res.get("done") is True:
+            console.print(f"  [green]✓[/green] {namespace}/{registry_path} ({size:,} bytes, chunked)")
+            return "uploaded"
+    console.print(f"  [red]✗[/red] finalize did not complete for {registry_path} after {max_steps} steps")
     return "failed"
 
 


### PR DESCRIPTION
## Summary
- After #223, the `Publish Main` run got past the frontend build but failed uploading the 1.8 MB `realm_backend` WASM to the test file_registry with `IC0522` (exceeded 40B instructions/message).
- Root cause: `_upload_one_file` called the one-shot `finalize_chunked_file`, which reassembles + sha256-hashes the whole file in a single message.
- Fix: poll the canister's existing `finalize_chunked_file_step` (batched byte-copy, on-chain hashing skipped, locally-computed sha256 passed once). Verified the method is live on the test file_registry (`uq2mu`).

## Test plan
- [ ] `Publish Main` builds + publishes the main snapshot to `test` (backend WASM finalize completes).

Made with [Cursor](https://cursor.com)